### PR TITLE
KBV-360 Add missing mappings for staging params

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -74,12 +74,12 @@ Mappings:
       integration: "ES256"
       production: "ES256"
 
-  IPVCoreStubAudience:
+  IPVCoreStubAudienceMapping:
     Environment:
       dev: "https://dev.address.cri.account.gov.uk"
       build: "https://build.address.cri.account.gov.uk"
 
-  IPVCore1Audience:
+  IPVCore1AudienceMapping:
     Environment:
       staging: "https://staging-di-ipv-cri-address-stub.london.cloudapps.digital"
       integration: "https://integration-di-ipv-cri-address-stub.london.cloudapps.digital"
@@ -111,9 +111,8 @@ Mappings:
     Environment:
       dev: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
       build: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
-      production: "https://di-ipv-core-front.london.cloudapps.digital/credential-issuer/callback"
 
-  IPVCoreClient1RedirectURIMapping:
+  IPVCore1RedirectURIMapping:
     Environment:
       staging: "https://staging-di-ipv-core-front.london.cloudapps.digital/credential-issuer/callback"
       integration: "https://integration-di-ipv-core-front.london.cloudapps.digital/credential-issuer/callback"
@@ -553,7 +552,7 @@ Resources:
     Properties:
       Name: !Sub "/${AWS::StackName}/clients/ipv-core-stub/jwtAuthentication/audience"
       Type: String
-      Value: !FindInMap [ IPVCoreStubAudience, Environment, !Ref 'Environment' ]
+      Value: !FindInMap [ IPVCoreStubAudienceMapping, Environment, !Ref 'Environment' ]
 
   IPVCore1AudienceParameter:
     Condition: IsProdLikeEnvironment
@@ -561,7 +560,7 @@ Resources:
     Properties:
       Name: !Sub "/${AWS::StackName}/clients/ipv-core/jwtAuthentication/audience"
       Type: String
-      Value: !FindInMap [ IPVCore1Audience, Environment, !Ref 'Environment' ]
+      Value: !FindInMap [ IPVCore1AudienceMapping, Environment, !Ref 'Environment' ]
 
   IPVCoreStubIssuerParameter:
     Condition: IsStubEnvironment


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Fix the following CodePipeline error when deploying to staging:
````
Error: Failed to create changeset for the stack: di-ipv-cri-address-api, ex: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "FAILED" Status: FAILED. Reason: Template error: Mapping named 'IPVCore1RedirectURIMapping' is not present in the 'Mappings' section of template.
````

I've tested this on a personal stack by setting Environment to `staging` and performing a successful sam deploy.

### Why did it change

CodePipeline deploy to staging was borked.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-360](https://govukverify.atlassian.net/browse/KBV-360)
