### PR TITLE
OJ-2113: Increase usage plan

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,10 +76,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -235,5 +231,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-21T10:14:01Z"
+  "generated_at": "2023-12-12T16:37:43Z"
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -620,7 +620,7 @@ Resources:
         Period: DAY
       Throttle:
         BurstLimit: 200 # requests the API can handle concurrently
-        RateLimit: 100 # allowed requests per second
+        RateLimit: 400 # allowed requests per second
 
   PrivateAddressApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
@@ -636,7 +636,7 @@ Resources:
         Period: DAY
       Throttle:
         BurstLimit: 200 # requests the API can handle concurrently
-        RateLimit: 100 # allowed requests per second
+        RateLimit: 400 # allowed requests per second
 
   LinkUsagePlanApiKey1:
     Type: AWS::ApiGateway::UsagePlanKey


### PR DESCRIPTION
## Proposed changes

### What changed
Rate Limits in the Usage Plan

### Why did it change
HTTP 429s occurred during the performance testing. The usage plan had a smaller burst limit than what was set as the limits for the API gateway. By design, AWS uses the lower value between the Usage Plan and API Gateway. This PR sets them to both be the same.

### Issue tracking
- [OJ-2113](https://govukverify.atlassian.net/browse/OJ-2113)


[OJ-2113]: https://govukverify.atlassian.net/browse/OJ-2113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ