### PR TITLE
OJ-2209: Set SonarCloud project name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,7 @@ subprojects {
 
 sonar {
 	properties {
+		property "sonar.projectName", "ipv-cri-address-api-java"
 		property "sonar.projectKey", "ipv-cri-address-api-java"
 		property "sonar.organization", "govuk-one-login"
 		property "sonar.host.url", "https://sonarcloud.io"


### PR DESCRIPTION
By default, SonarCloud sets the project name based on the gradle project name, so it needs to be overriden.