### PR TITLE
BAU: Adjust the additional eslint config to only include config files in lambdas/get-addresses root

### DIFF
--- a/lambdas/get-addresses/tsconfig.eslint.json
+++ b/lambdas/get-addresses/tsconfig.eslint.json
@@ -3,5 +3,5 @@
         "noEmit": true
     },
     // Additional paths to lint not included by other tsconfig.json files
-    "include": ["**/**/.*.js", "**/**/*.js", "**/**/*.ts"]
+    "include": ["./.*.js", "./*.js", "./*.ts"]
 }


### PR DESCRIPTION
It shouldn't include all the files in the lambdas/get-addresses directory, only the root config files.