### PR TITLE
Incident-641: fix null pointer os api addr

### DIFF
--- a/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
+++ b/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
@@ -197,6 +197,25 @@ class PostcodeLookupServiceTest {
     }
 
     @Test
+    void shouldReplicateNullPointExceptionIncident641() throws IOException, InterruptedException {
+        // Mock a valid url so service doesn't fall over validating URI
+        when(mockConfigurationService.getParameterValue("OrdnanceSurveyAPIURL"))
+                .thenReturn("http://localhost:8080/");
+        // Simulate a 200 response
+        when(mockResponse.statusCode()).thenReturn(HttpStatusCode.OK);
+        String ordnanceSurvey200ResponseNotContainResults =
+                "{\"header\":{\"uri\":\"http://localhost:8080/postcode?postcode=ZZ1+1ZZ\",\"query\":\"postcode=ZZ11ZZ\",\"offset\":0,\"totalresults\":32,\"format\":\"JSON\",\"dataset\":\"DPA\",\"lr\":\"EN,CY\",\"maxresults\":1000,\"epoch\":\"90\",\"output_srs\":\"EPSG:27700\"}}";
+        when(mockResponse.body()).thenReturn(ordnanceSurvey200ResponseNotContainResults);
+
+        when(httpClient.send(
+                        any(HttpRequest.class),
+                        ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+                .thenReturn(mockResponse);
+        assertThrows(
+                NullPointerException.class, () -> postcodeLookupService.lookupPostcode("ZZ1 1ZZ"));
+    }
+
+    @Test
     void shouldUrlDecodePost() throws IOException, InterruptedException {
         String urlEncodedPostcode = "ZZ1%201ZZ";
         // Mock a valid url so service doesn't fall over validating URI

--- a/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
+++ b/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.ipv.cri.address.api.service;
 
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -35,6 +36,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -197,22 +199,49 @@ class PostcodeLookupServiceTest {
     }
 
     @Test
-    void shouldReplicateNullPointExceptionIncident641() throws IOException, InterruptedException {
+    @DisplayName(
+            "it should return empty when response from Ordnance Survey is a 200 and results contains object with Dpa")
+    void shouldReturnEmptyWhenResponseFromOrdnanceSurveyIsA200WithoutResults()
+            throws IOException, InterruptedException {
         // Mock a valid url so service doesn't fall over validating URI
         when(mockConfigurationService.getParameterValue("OrdnanceSurveyAPIURL"))
                 .thenReturn("http://localhost:8080/");
         // Simulate a 200 response
         when(mockResponse.statusCode()).thenReturn(HttpStatusCode.OK);
-        String ordnanceSurvey200ResponseNotContainResults =
-                "{\"header\":{\"uri\":\"http://localhost:8080/postcode?postcode=ZZ1+1ZZ\",\"query\":\"postcode=ZZ11ZZ\",\"offset\":0,\"totalresults\":32,\"format\":\"JSON\",\"dataset\":\"DPA\",\"lr\":\"EN,CY\",\"maxresults\":1000,\"epoch\":\"90\",\"output_srs\":\"EPSG:27700\"}}";
-        when(mockResponse.body()).thenReturn(ordnanceSurvey200ResponseNotContainResults);
+        String ok200payloadWithoutResults =
+                "{\"header\":{\"uri\":\"http://localhost:8080/postcode?postcode=ZZ1+1ZZ\",\"query\":\"postcode=ZZ11ZZ\",\"offset\":0,\"totalresults\":32,\"format\":\"JSON\",\"dataset\":\"DPA\",\"lr\":\"EN,CY\",\"maxresults\":1000,\"epoch\":\"90\",\"output_srs\":\"EPSG:27700\"}},\"results\":[{\"DPA\"}]";
+        when(mockResponse.body()).thenReturn(ok200payloadWithoutResults);
 
         when(httpClient.send(
                         any(HttpRequest.class),
                         ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
                 .thenReturn(mockResponse);
-        assertThrows(
-                NullPointerException.class, () -> postcodeLookupService.lookupPostcode("ZZ1 1ZZ"));
+
+        assertTrue(postcodeLookupService.lookupPostcode("ZZ1 1ZZ").isEmpty());
+        verify(log).warn(contains("PostCode lookup returned no results"));
+    }
+
+    @Test
+    @DisplayName(
+            "it should return empty when response from Ordnance Survey is a 200 and no results provided")
+    void shouldReturnEmptyWhenResponseFromOrdnanceSurveyIsA200WResultsArrayEmpty()
+            throws IOException, InterruptedException {
+        // Mock a valid url so service doesn't fall over validating URI
+        when(mockConfigurationService.getParameterValue("OrdnanceSurveyAPIURL"))
+                .thenReturn("http://localhost:8080/");
+        // Simulate a 200 response
+        when(mockResponse.statusCode()).thenReturn(HttpStatusCode.OK);
+        String ok200PayloadResultsEmpty =
+                "{\"header\":{\"uri\":\"http://localhost:8080/postcode?postcode=ZZ1+1ZZ\",\"query\":\"postcode=ZZ11ZZ\",\"offset\":0,\"totalresults\":32,\"format\":\"JSON\",\"dataset\":\"DPA\",\"lr\":\"EN,CY\",\"maxresults\":1000,\"epoch\":\"90\",\"output_srs\":\"EPSG:27700\"},\"results\":[]}";
+        when(mockResponse.body()).thenReturn(ok200PayloadResultsEmpty);
+
+        when(httpClient.send(
+                        any(HttpRequest.class),
+                        ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+                .thenReturn(mockResponse);
+
+        assertTrue(postcodeLookupService.lookupPostcode("ZZ1 1ZZ").isEmpty());
+        verifyNoInteractions(log);
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

NullPointerException occurs see index="gds_di_production" functionName=address-cri-api-* di-ipv-cri-address-api-postcode-lookup level=ERROR

### What changed

Log warning instead and return an empty list

### Why did it change

NullPointerException maybe causing unwanted UI behavior see ticket
