### PR TITLE
OJ-2240: add address to restricted fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ subprojects {
 	}
 
 	repositories {
-		mavenLocal()
 		maven {
 			url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "1.5.2"
+		cri_common_lib           : "1.5.5"
 	]
 }
 
@@ -35,6 +35,7 @@ subprojects {
 	}
 
 	repositories {
+		mavenLocal()
 		maven {
 			url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
 		}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
@@ -28,7 +28,6 @@ import uk.gov.di.ipv.cri.address.api.service.VerifiableCredentialService;
 import uk.gov.di.ipv.cri.address.library.service.AddressService;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventContext;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventType;
-import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
 import uk.gov.di.ipv.cri.common.library.error.ErrorResponse;
 import uk.gov.di.ipv.cri.common.library.exception.AccessTokenExpiredException;
 import uk.gov.di.ipv.cri.common.library.exception.SessionExpiredException;
@@ -37,6 +36,7 @@ import uk.gov.di.ipv.cri.common.library.exception.SqsException;
 import uk.gov.di.ipv.cri.common.library.service.AuditEventFactory;
 import uk.gov.di.ipv.cri.common.library.service.AuditService;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.service.PersonIdentityDetailedFactory;
 import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.ApiGatewayResponseGenerator;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
@@ -116,7 +116,7 @@ public class IssueCredentialHandler
 
             AuditEventContext auditEventContext =
                     new AuditEventContext(
-                            new PersonIdentityDetailed(
+                            PersonIdentityDetailedFactory.createPersonIdentityDetailedWithAddresses(
                                     null,
                                     null,
                                     addressService.mapCanonicalAddresses(

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
@@ -121,7 +121,7 @@ public class AddressService {
     public List<Address> mapCanonicalAddresses(List<CanonicalAddress> addresses) {
         return addresses.stream()
                 .map(
-                        (address) -> {
+                        address -> {
                             Address mappedAddress = new Address();
                             mappedAddress.setAddressCountry(address.getAddressCountry());
                             mappedAddress.setAddressLocality(address.getAddressLocality());

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
@@ -9,7 +9,6 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.address.library.exception.AddressProcessingException;
 import uk.gov.di.ipv.cri.address.library.persistence.item.AddressItem;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
-import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
@@ -17,7 +16,6 @@ import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 public class AddressService {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -116,33 +114,6 @@ public class AddressService {
                 // Only the CURRENT address has date information.
                 throw new AddressProcessingException(ERROR_TOO_MANY_ADDRESSES);
         }
-    }
-
-    public List<Address> mapCanonicalAddresses(List<CanonicalAddress> addresses) {
-        return addresses.stream()
-                .map(
-                        address -> {
-                            Address mappedAddress = new Address();
-                            mappedAddress.setAddressCountry(address.getAddressCountry());
-                            mappedAddress.setAddressLocality(address.getAddressLocality());
-                            mappedAddress.setBuildingName(address.getBuildingName());
-                            mappedAddress.setBuildingNumber(address.getBuildingNumber());
-                            mappedAddress.setDepartmentName(address.getDepartmentName());
-                            mappedAddress.setDependentAddressLocality(
-                                    address.getDependentAddressLocality());
-                            mappedAddress.setDependentStreetName(address.getDependentStreetName());
-                            mappedAddress.setDoubleDependentAddressLocality(
-                                    address.getDoubleDependentAddressLocality());
-                            mappedAddress.setOrganisationName(address.getOrganisationName());
-                            mappedAddress.setPostalCode(address.getPostalCode());
-                            mappedAddress.setStreetName(address.getStreetName());
-                            mappedAddress.setSubBuildingName(address.getSubBuildingName());
-                            mappedAddress.setUprn(address.getUprn());
-                            mappedAddress.setValidFrom(address.getValidFrom());
-                            mappedAddress.setValidUntil(address.getValidUntil());
-                            return mappedAddress;
-                        })
-                .collect(Collectors.toList());
     }
 
     private void processAddresses(List<CanonicalAddress> addresses)

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.ipv.cri.address.library.exception.AddressProcessingException;
 import uk.gov.di.ipv.cri.address.library.persistence.item.AddressItem;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
@@ -16,6 +17,7 @@ import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class AddressService {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -114,6 +116,33 @@ public class AddressService {
                 // Only the CURRENT address has date information.
                 throw new AddressProcessingException(ERROR_TOO_MANY_ADDRESSES);
         }
+    }
+
+    public List<Address> mapCanonicalAddresses(List<CanonicalAddress> addresses) {
+        return addresses.stream()
+                .map(
+                        (address) -> {
+                            Address mappedAddress = new Address();
+                            mappedAddress.setAddressCountry(address.getAddressCountry());
+                            mappedAddress.setAddressLocality(address.getAddressLocality());
+                            mappedAddress.setBuildingName(address.getBuildingName());
+                            mappedAddress.setBuildingNumber(address.getBuildingNumber());
+                            mappedAddress.setDepartmentName(address.getDepartmentName());
+                            mappedAddress.setDependentAddressLocality(
+                                    address.getDependentAddressLocality());
+                            mappedAddress.setDependentStreetName(address.getDependentStreetName());
+                            mappedAddress.setDoubleDependentAddressLocality(
+                                    address.getDoubleDependentAddressLocality());
+                            mappedAddress.setOrganisationName(address.getOrganisationName());
+                            mappedAddress.setPostalCode(address.getPostalCode());
+                            mappedAddress.setStreetName(address.getStreetName());
+                            mappedAddress.setSubBuildingName(address.getSubBuildingName());
+                            mappedAddress.setUprn(address.getUprn());
+                            mappedAddress.setValidFrom(address.getValidFrom());
+                            mappedAddress.setValidUntil(address.getValidUntil());
+                            return mappedAddress;
+                        })
+                .collect(Collectors.toList());
     }
 
     private void processAddresses(List<CanonicalAddress> addresses)

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.ipv.cri.address.library.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -15,7 +14,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.address.library.exception.AddressProcessingException;
 import uk.gov.di.ipv.cri.address.library.persistence.item.AddressItem;
-import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
 import uk.gov.di.ipv.cri.common.library.util.deserializers.PiiRedactingDeserializer;
@@ -29,7 +27,6 @@ import java.util.UUID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -201,8 +198,7 @@ class AddressServiceTest {
         }
 
         @Test
-        void shouldPersistAnEmptyListOfAddressesWhenNoListOfCanonicalAddressesIsSupplied()
-                throws JsonProcessingException {
+        void shouldPersistAnEmptyListOfAddressesWhenNoListOfCanonicalAddressesIsSupplied() {
             addressService.saveAddresses(SESSION_ID, null);
             ArgumentCaptor<AddressItem> addressItemArgumentCaptor =
                     ArgumentCaptor.forClass(AddressItem.class);
@@ -587,80 +583,5 @@ class AddressServiceTest {
     void shouldGetAddressItem() {
         addressService.getAddressItem(SESSION_ID);
         verify(mockDataStore).getItem(String.valueOf(SESSION_ID));
-    }
-
-    @Nested
-    @DisplayName("Address Service maps canonical addresses to addresses")
-    class AddressServiceMapCanonicalAddresses {
-        @Test
-        void shouldNotErrorWhenMappingCanonicalAddresesOnEmptyInput() {
-            assertDoesNotThrow(() -> addressService.mapCanonicalAddresses(Collections.emptyList()));
-        }
-
-        @Test
-        void shouldMapCanonicalAddressesToAddresses() {
-            CanonicalAddress address = new CanonicalAddress();
-            address.setBuildingNumber("buildingNum");
-            address.setStreetName("street");
-            address.setPostalCode("postcode");
-
-            CanonicalAddress previousAddress = new CanonicalAddress();
-            previousAddress.setBuildingNumber("buildingNum");
-            previousAddress.setStreetName("street");
-            previousAddress.setPostalCode("postcode");
-
-            List<Address> mappedAddresses =
-                    addressService.mapCanonicalAddresses(List.of(address, previousAddress));
-            mappedAddresses.forEach(
-                    mappedAddress -> {
-                        assertAll(
-                                () -> {
-                                    assertEquals(
-                                            address.getAddressCountry(),
-                                            mappedAddress.getAddressCountry());
-                                    assertEquals(
-                                            address.getAddressLocality(),
-                                            mappedAddress.getAddressLocality());
-                                    assertEquals(
-                                            address.getDependentAddressLocality(),
-                                            mappedAddress.getDependentAddressLocality());
-                                    assertEquals(
-                                            address.getBuildingName(),
-                                            mappedAddress.getBuildingName());
-                                    assertEquals(
-                                            address.getDepartmentName(),
-                                            mappedAddress.getDepartmentName());
-                                    assertEquals(
-                                            address.getBuildingNumber(),
-                                            mappedAddress.getBuildingNumber());
-                                    assertEquals(
-                                            address.getDependentStreetName(),
-                                            mappedAddress.getDependentStreetName());
-                                    assertEquals(
-                                            address.getDoubleDependentAddressLocality(),
-                                            mappedAddress.getDoubleDependentAddressLocality());
-                                    assertEquals(
-                                            address.getOrganisationName(),
-                                            mappedAddress.getOrganisationName());
-                                    assertEquals(
-                                            address.getStreetName(), mappedAddress.getStreetName());
-                                    assertEquals(
-                                            address.getSubBuildingName(),
-                                            mappedAddress.getSubBuildingName());
-                                    assertEquals(address.getUprn(), mappedAddress.getUprn());
-                                    assertEquals(
-                                            address.getPostalCode(), mappedAddress.getPostalCode());
-                                });
-                    });
-        }
-
-        @Test
-        void shouldReturnTrueWithNULLNULLFormatDates() {
-            CanonicalAddress address = new CanonicalAddress();
-            address.setValidFrom(null);
-            address.setValidUntil(null);
-
-            assertTrue(addressService.isNotCurrentAddress(address));
-        }
     }
 }

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
@@ -549,8 +549,8 @@ class AddressServiceTest {
     }
 
     @Nested
-    @DisplayName("Address Service Is an InValid Address")
-    class AddressServiceIsInValidAddress {
+    @DisplayName("Address Service is supplied an invalid Address")
+    class AddressServiceIsSuppliedInvalidAddress {
         @Test
         void shouldReturnTrueWithInvalidFormatDates() {
             CanonicalAddress address = new CanonicalAddress();

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
@@ -1,10 +1,13 @@
 package uk.gov.di.ipv.cri.address.library.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -12,17 +15,21 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.address.library.exception.AddressProcessingException;
 import uk.gov.di.ipv.cri.address.library.persistence.item.AddressItem;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.persistence.DataStore;
 import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
 import uk.gov.di.ipv.cri.common.library.util.deserializers.PiiRedactingDeserializer;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -63,157 +70,517 @@ class AddressServiceTest {
         this.addressService = new AddressService(mockDataStore, objectMapper);
     }
 
-    @Test
-    void shouldParseAddresses() throws AddressProcessingException {
-        String addresses =
-                "[\n"
-                        + "   {\n"
-                        + "      \"uprn\": \"72262801\",\n"
-                        + "      \"buildingNumber\": \"8\",\n"
-                        + "      \"streetName\": \"GRANGE FIELDS WAY\",\n"
-                        + "      \"addressLocality\": \"LEEDS\",\n"
-                        + "      \"postalCode\": \"LS10 4QL\",\n"
-                        + "      \"addressCountry\": \"GB\",\n"
-                        + "      \"validFrom\": \"2010-02-26\",\n"
-                        + "      \"validUntil\": \"2021-01-16\"\n"
-                        + "   },\n"
-                        + "   {\n"
-                        + "      \"uprn\": \"63094965\",\n"
-                        + "      \"buildingNumber\": \"15\",\n"
-                        + "      \"dependentLocality\": \"LOFTHOUSE\",\n"
-                        + "      \"streetName\": \"RIDINGS LANE\",\n"
-                        + "      \"addressLocality\": \"WAKEFIELD\",\n"
-                        + "      \"postalCode\": \"WF3 3SE\",\n"
-                        + "      \"addressCountry\": \"GB\",\n"
-                        + "      \"validFrom\": \"2021-01-16\",\n"
-                        + "      \"validUntil\": \"2021-08-02\"\n"
-                        + "   },\n"
-                        + "   {\n"
-                        + "      \"uprn\": \"63042351\",\n"
-                        + "      \"buildingNumber\": \"5\",\n"
-                        + "      \"streetName\": \"GATEWAYS\",\n"
-                        + "      \"addressLocality\": \"WAKEFIELD\",\n"
-                        + "      \"postalCode\": \"WF1 2LZ\",\n"
-                        + "      \"addressCountry\": \"GB\",\n"
-                        + "      \"validFrom\": \"2021-08-02\"\n"
-                        + "   }\n"
-                        + "]";
+    @Nested
+    @DisplayName("AddressService parses an Address")
+    class AddressServiceParseAddresses {
+        @Test
+        void shouldParseAddresses() throws AddressProcessingException {
+            String addresses =
+                    "[\n"
+                            + "   {\n"
+                            + "      \"uprn\": \"72262801\",\n"
+                            + "      \"buildingNumber\": \"8\",\n"
+                            + "      \"streetName\": \"GRANGE FIELDS WAY\",\n"
+                            + "      \"addressLocality\": \"LEEDS\",\n"
+                            + "      \"postalCode\": \"LS10 4QL\",\n"
+                            + "      \"addressCountry\": \"GB\",\n"
+                            + "      \"validFrom\": \"2010-02-26\",\n"
+                            + "      \"validUntil\": \"2021-01-16\"\n"
+                            + "   },\n"
+                            + "   {\n"
+                            + "      \"uprn\": \"63094965\",\n"
+                            + "      \"buildingNumber\": \"15\",\n"
+                            + "      \"dependentLocality\": \"LOFTHOUSE\",\n"
+                            + "      \"streetName\": \"RIDINGS LANE\",\n"
+                            + "      \"addressLocality\": \"WAKEFIELD\",\n"
+                            + "      \"postalCode\": \"WF3 3SE\",\n"
+                            + "      \"addressCountry\": \"GB\",\n"
+                            + "      \"validFrom\": \"2021-01-16\",\n"
+                            + "      \"validUntil\": \"2021-08-02\"\n"
+                            + "   },\n"
+                            + "   {\n"
+                            + "      \"uprn\": \"63042351\",\n"
+                            + "      \"buildingNumber\": \"5\",\n"
+                            + "      \"streetName\": \"GATEWAYS\",\n"
+                            + "      \"addressLocality\": \"WAKEFIELD\",\n"
+                            + "      \"postalCode\": \"WF1 2LZ\",\n"
+                            + "      \"addressCountry\": \"GB\",\n"
+                            + "      \"validFrom\": \"2021-08-02\"\n"
+                            + "   }\n"
+                            + "]";
 
-        List<CanonicalAddress> parsedAddresses = addressService.parseAddresses(addresses);
+            List<CanonicalAddress> parsedAddresses = addressService.parseAddresses(addresses);
 
-        assertThat(parsedAddresses.size(), equalTo(3));
+            assertThat(parsedAddresses.size(), equalTo(3));
+        }
+
+        @Test
+        void shouldNotRevealPIIAddressDetailWhenAnInvalidDateIsSupplied() {
+            String addresses =
+                    "[\n"
+                            + "   {\n"
+                            + "      \"uprn\": \"72262801\",\n"
+                            + "      \"buildingNumber\": \"8\",\n"
+                            + "      \"streetName\": \"GRANGE FIELDS WAY\",\n"
+                            + "      \"addressLocality\": \"LEEDS\",\n"
+                            + "      \"postalCode\": \"LS10 4QL\",\n"
+                            + "      \"addressCountry\": \"GB\",\n"
+                            + "      \"validFrom\": \"2010-00-00\",\n"
+                            + "      \"validUntil\": \"2021-01-16\"\n"
+                            + "   },\n"
+                            + "]";
+
+            AddressProcessingException addressProcessingException =
+                    assertThrows(
+                            AddressProcessingException.class,
+                            () -> addressService.parseAddresses(addresses));
+
+            assertThat(
+                    addressProcessingException.getMessage(),
+                    containsString(
+                            String.format(
+                                    "could not parse addresses...Error while deserializing object. Some PII fields were redacted. {\"uprn\":\"%s\",\"buildingNumber\":\"*\",\"streetName\":\"%s\",\"addressLocality\":\"%s\",\"postalCode\":\"%s\",\"addressCountry\":\"%s\",\"validFrom\":\"**********\",\"validUntil\":\"**********\"}",
+                                    "*".repeat("72262801".length()),
+                                    "*".repeat("GRANGE FIELDS WAY".length()),
+                                    "*".repeat("LEEDS".length()),
+                                    "*".repeat("LS10 4QL".length()),
+                                    "*".repeat("GB".length()),
+                                    "*".repeat("2010-00-00".length()),
+                                    "*".repeat("2021-01-16".length()))));
+        }
     }
 
-    @Test
-    void shouldNotRevealPIIAddressDetailWhenAnInvalidDateIsSupplied() {
-        String addresses =
-                "[\n"
-                        + "   {\n"
-                        + "      \"uprn\": \"72262801\",\n"
-                        + "      \"buildingNumber\": \"8\",\n"
-                        + "      \"streetName\": \"GRANGE FIELDS WAY\",\n"
-                        + "      \"addressLocality\": \"LEEDS\",\n"
-                        + "      \"postalCode\": \"LS10 4QL\",\n"
-                        + "      \"addressCountry\": \"GB\",\n"
-                        + "      \"validFrom\": \"2010-00-00\",\n"
-                        + "      \"validUntil\": \"2021-01-16\"\n"
-                        + "   },\n"
-                        + "]";
+    @Nested
+    @DisplayName("AddressService saves an Address")
+    class AddressServiceSaveAddresses {
+        @Test
+        void shouldPersistAddresses() {
+            List<CanonicalAddress> addresses = new ArrayList<>();
+            CanonicalAddress address1 = new CanonicalAddress();
+            address1.setUprn(Long.valueOf("72262801"));
+            address1.setBuildingNumber("8");
+            address1.setStreetName("GRANGE FIELDS WAY");
+            address1.setAddressLocality("LEEDS");
+            address1.setPostalCode("LS10 4QL");
+            address1.setAddressCountry("GB");
+            address1.setValidFrom(LocalDate.of(2010, 2, 26));
+            address1.setValidUntil(LocalDate.of(2021, 1, 16));
 
-        AddressProcessingException addressProcessingException =
-                assertThrows(
-                        AddressProcessingException.class,
-                        () -> addressService.parseAddresses(addresses));
+            CanonicalAddress address2 = new CanonicalAddress();
+            address2.setUprn(Long.valueOf("63094965"));
+            address2.setBuildingNumber("15");
+            address2.setStreetName("RIDINGS LANE");
+            address2.setDependentAddressLocality("LOFTHOUSE");
+            address2.setAddressLocality("WAKEFIELD");
+            address2.setPostalCode("WF3 3SE");
+            address2.setAddressCountry("GB");
+            address2.setValidFrom(LocalDate.of(2021, 1, 16));
+            address2.setValidUntil(LocalDate.of(2021, 8, 2));
 
-        assertThat(
-                addressProcessingException.getMessage(),
-                containsString(
-                        String.format(
-                                "could not parse addresses...Error while deserializing object. Some PII fields were redacted. {\"uprn\":\"%s\",\"buildingNumber\":\"*\",\"streetName\":\"%s\",\"addressLocality\":\"%s\",\"postalCode\":\"%s\",\"addressCountry\":\"%s\",\"validFrom\":\"**********\",\"validUntil\":\"**********\"}",
-                                "*".repeat("72262801".length()),
-                                "*".repeat("GRANGE FIELDS WAY".length()),
-                                "*".repeat("LEEDS".length()),
-                                "*".repeat("LS10 4QL".length()),
-                                "*".repeat("GB".length()),
-                                "*".repeat("2010-00-00".length()),
-                                "*".repeat("2021-01-16".length()))));
+            CanonicalAddress address3 = new CanonicalAddress();
+            address3.setUprn(Long.valueOf("63042351"));
+            address3.setBuildingNumber("5");
+            address3.setStreetName("GATEWAYS");
+            address3.setAddressLocality("WAKEFIELD");
+            address3.setPostalCode("WF1 2LZ");
+            address3.setAddressCountry("GB");
+            address3.setValidFrom(LocalDate.of(2021, 8, 2));
+
+            addresses.add(address1);
+            addresses.add(address2);
+            addresses.add(address3);
+
+            addressService.saveAddresses(SESSION_ID, addresses);
+            ArgumentCaptor<AddressItem> addressItemArgumentCaptor =
+                    ArgumentCaptor.forClass(AddressItem.class);
+            verify(mockDataStore).create(addressItemArgumentCaptor.capture());
+            MatcherAssert.assertThat(
+                    addressItemArgumentCaptor.getValue().getAddresses(), equalTo(addresses));
+            MatcherAssert.assertThat(
+                    addressItemArgumentCaptor.getValue().getSessionId(), equalTo(SESSION_ID));
+        }
+
+        @Test
+        void shouldPersistAnEmptyListOfAddressesWhenNoListOfCanonicalAddressesIsSupplied()
+                throws JsonProcessingException {
+            addressService.saveAddresses(SESSION_ID, null);
+            ArgumentCaptor<AddressItem> addressItemArgumentCaptor =
+                    ArgumentCaptor.forClass(AddressItem.class);
+            verify(mockDataStore).create(addressItemArgumentCaptor.capture());
+            MatcherAssert.assertThat(
+                    addressItemArgumentCaptor.getValue().getAddresses(),
+                    equalTo(new ArrayList<>()));
+            MatcherAssert.assertThat(
+                    addressItemArgumentCaptor.getValue().getSessionId(), equalTo(SESSION_ID));
+        }
     }
 
-    @Test
-    void shouldPersistAddresses() {
-        List<CanonicalAddress> addresses = new ArrayList<>();
-        CanonicalAddress address1 = new CanonicalAddress();
-        address1.setUprn(Long.valueOf("72262801"));
-        address1.setBuildingNumber("8");
-        address1.setStreetName("GRANGE FIELDS WAY");
-        address1.setAddressLocality("LEEDS");
-        address1.setPostalCode("LS10 4QL");
-        address1.setAddressCountry("GB");
-        address1.setValidFrom(LocalDate.of(2010, 2, 26));
-        address1.setValidUntil(LocalDate.of(2021, 1, 16));
+    @Nested
+    @DisplayName("AddressService sets country when absent")
+    class AddressServiceSetAddressCountryIfMissing {
+        @Test
+        void shouldSetAddressCountryIfNotProvided() {
+            List<CanonicalAddress> addresses = new ArrayList<>();
+            CanonicalAddress address1 = new CanonicalAddress();
+            address1.setPostalCode("LS10 4QL");
+            address1.setAddressCountry("GB");
+            address1.setValidFrom(LocalDate.of(2010, 2, 26));
+            address1.setValidUntil(LocalDate.of(2021, 1, 16));
 
-        CanonicalAddress address2 = new CanonicalAddress();
-        address2.setUprn(Long.valueOf("63094965"));
-        address2.setBuildingNumber("15");
-        address2.setStreetName("RIDINGS LANE");
-        address2.setDependentAddressLocality("LOFTHOUSE");
-        address2.setAddressLocality("WAKEFIELD");
-        address2.setPostalCode("WF3 3SE");
-        address2.setAddressCountry("GB");
-        address2.setValidFrom(LocalDate.of(2021, 1, 16));
-        address2.setValidUntil(LocalDate.of(2021, 8, 2));
+            CanonicalAddress address2 = new CanonicalAddress();
+            address2.setPostalCode("WF3 3SE");
+            address2.setAddressCountry("FR");
+            address2.setValidFrom(LocalDate.of(2021, 1, 16));
+            address2.setValidUntil(LocalDate.of(2021, 8, 2));
 
-        CanonicalAddress address3 = new CanonicalAddress();
-        address3.setUprn(Long.valueOf("63042351"));
-        address3.setBuildingNumber("5");
-        address3.setStreetName("GATEWAYS");
-        address3.setAddressLocality("WAKEFIELD");
-        address3.setPostalCode("WF1 2LZ");
-        address3.setAddressCountry("GB");
-        address3.setValidFrom(LocalDate.of(2021, 8, 2));
+            CanonicalAddress address3 = new CanonicalAddress();
+            address3.setPostalCode("WF1 2LZ");
+            address3.setValidFrom(LocalDate.of(2021, 8, 2));
 
-        addresses.add(address1);
-        addresses.add(address2);
-        addresses.add(address3);
+            addresses.add(address1);
+            addresses.add(address2);
+            addresses.add(address3);
 
-        addressService.saveAddresses(SESSION_ID, addresses);
-        ArgumentCaptor<AddressItem> addressItemArgumentCaptor =
-                ArgumentCaptor.forClass(AddressItem.class);
-        verify(mockDataStore).create(addressItemArgumentCaptor.capture());
-        MatcherAssert.assertThat(
-                addressItemArgumentCaptor.getValue().getAddresses(), equalTo(addresses));
-        MatcherAssert.assertThat(
-                addressItemArgumentCaptor.getValue().getSessionId(), equalTo(SESSION_ID));
+            addressService.setAddressCountryIfMissing(addresses);
+
+            MatcherAssert.assertThat(address1.getAddressCountry(), equalTo("GB"));
+            MatcherAssert.assertThat(address2.getAddressCountry(), equalTo("FR"));
+            MatcherAssert.assertThat(address3.getAddressCountry(), equalTo("GB"));
+        }
+
+        @Test
+        void shouldNotThrowAnErrorWhenSetAddressCountryIfNotProvidedIsPassedAnEmptyList() {
+            assertDoesNotThrow(
+                    () -> addressService.setAddressCountryIfMissing(Collections.emptyList()));
+        }
     }
 
-    @Test
-    void shouldSetAddressCountryIfNotProvided() {
-        List<CanonicalAddress> addresses = new ArrayList<>();
-        CanonicalAddress address1 = new CanonicalAddress();
-        address1.setPostalCode("LS10 4QL");
-        address1.setAddressCountry("GB");
-        address1.setValidFrom(LocalDate.of(2010, 2, 26));
-        address1.setValidUntil(LocalDate.of(2021, 1, 16));
+    @Nested
+    @DisplayName("AddressService sets Address Validity")
+    class AddressServiceSetAddressValidity {
+        @Test
+        void shouldSucceedWithNoAddresses() {
+            List<CanonicalAddress> canonicalAddresses = new ArrayList<>();
+            assertDoesNotThrow(() -> addressService.setAddressValidity(canonicalAddresses));
+        }
 
-        CanonicalAddress address2 = new CanonicalAddress();
-        address2.setPostalCode("WF3 3SE");
-        address2.setAddressCountry("FR");
-        address2.setValidFrom(LocalDate.of(2021, 1, 16));
-        address2.setValidUntil(LocalDate.of(2021, 8, 2));
+        @Test
+        void shouldEvaluateToPreviousWithNULLNULL() {
+            // The reason for the linker existing is that a second address, intended as
+            // a PREVIOUS address has ValidFrom and ValidUntil not set - null,null. This however
+            // matches the pattern for a CURRENT address with unknown start date.
+            // In this specific case, we evaluate null, null as the intended PREVIOUS address.
 
-        CanonicalAddress address3 = new CanonicalAddress();
-        address3.setPostalCode("WF1 2LZ");
-        address3.setValidFrom(LocalDate.of(2021, 8, 2));
+            CanonicalAddress currentAddress = new CanonicalAddress();
+            currentAddress.setValidFrom(null);
+            currentAddress.setValidUntil(null);
 
-        addresses.add(address1);
-        addresses.add(address2);
-        addresses.add(address3);
+            List<CanonicalAddress> canonicalAddresses = List.of(currentAddress);
 
-        addressService.setAddressCountryIfMissing(addresses);
+            AddressProcessingException exception =
+                    assertThrows(
+                            AddressProcessingException.class,
+                            () -> addressService.setAddressValidity(canonicalAddresses));
+            assertEquals(ERROR_SINGLE_ADDRESS_NOT_CURRENT, exception.getMessage());
+        }
 
-        MatcherAssert.assertThat(address1.getAddressCountry(), equalTo("GB"));
-        MatcherAssert.assertThat(address2.getAddressCountry(), equalTo("FR"));
-        MatcherAssert.assertThat(address3.getAddressCountry(), equalTo("GB"));
+        @Test
+        void shouldThrowExceptionWhenAboutToTrampleAlreadySetDates() {
+            // When AddressCRIFront is setting ValidUntil in previous addresses
+            // The linker can be removed entirely.
+
+            final LocalDate TEST_DATE_0 = LocalDate.of(1999, 12, 31);
+            final LocalDate TEST_DATE_1 = LocalDate.of(1999, 11, 30);
+
+            CanonicalAddress currentAddress = new CanonicalAddress();
+            currentAddress.setValidFrom(TEST_DATE_0);
+            currentAddress.setValidUntil(null);
+
+            CanonicalAddress previousAddress = new CanonicalAddress();
+            previousAddress.setValidFrom(null);
+            previousAddress.setValidUntil(TEST_DATE_1);
+
+            List<CanonicalAddress> canonicalAddresses = List.of(currentAddress, previousAddress);
+
+            AddressProcessingException exception =
+                    assertThrows(
+                            AddressProcessingException.class,
+                            () -> addressService.setAddressValidity(canonicalAddresses));
+
+            assertEquals(ERROR_ADDRESS_LINKING_NOT_NEEDED, exception.getMessage());
+        }
+
+        @Test
+        void shouldSucceedWithSingleCurrentAddress() {
+
+            LocalDate date = LocalDate.of(2013, 8, 9);
+
+            CanonicalAddress currentAddress = new CanonicalAddress();
+            currentAddress.setValidFrom(date);
+
+            List<CanonicalAddress> canonicalAddresses = List.of(currentAddress);
+
+            assertDoesNotThrow(() -> addressService.setAddressValidity(canonicalAddresses));
+        }
+
+        @Test
+        void shouldThrowExceptionWhenGivenSingleInvalidAddress() {
+
+            CanonicalAddress currentAddress = new CanonicalAddress();
+            currentAddress.setValidFrom(null);
+            currentAddress.setValidUntil(null);
+
+            List<CanonicalAddress> canonicalAddresses = List.of(currentAddress);
+
+            AddressProcessingException exception =
+                    assertThrows(
+                            AddressProcessingException.class,
+                            () -> addressService.setAddressValidity(canonicalAddresses));
+
+            assertEquals(ERROR_SINGLE_ADDRESS_NOT_CURRENT, exception.getMessage());
+        }
+
+        @Test
+        void shouldSucceedWithTwoValidAddresses() {
+
+            LocalDate date = LocalDate.of(2013, 8, 9);
+
+            CanonicalAddress currentAddress = new CanonicalAddress();
+            currentAddress.setValidFrom(date);
+
+            CanonicalAddress previousAddress = new CanonicalAddress();
+            previousAddress.setValidFrom(null);
+            previousAddress.setValidUntil(null);
+
+            assertNull(previousAddress.getValidUntil());
+
+            List<CanonicalAddress> canonicalAddresses = List.of(currentAddress, previousAddress);
+
+            assertDoesNotThrow(() -> addressService.setAddressValidity(canonicalAddresses));
+
+            // Linking performed
+            assertTrue(currentAddress.getValidFrom().isEqual(previousAddress.getValidUntil()));
+        }
+
+        @Test
+        void shouldSucceedWithTwoCurrentAddresses() {
+
+            LocalDate date = LocalDate.of(2013, 8, 9);
+
+            CanonicalAddress currentAddress0 = new CanonicalAddress();
+            currentAddress0.setValidFrom(date);
+
+            CanonicalAddress currentAddress1 = new CanonicalAddress();
+            currentAddress1.setValidFrom(date.plusYears(1));
+            currentAddress1.setValidUntil(null);
+
+            List<CanonicalAddress> canonicalAddresses = List.of(currentAddress0, currentAddress1);
+
+            assertDoesNotThrow(() -> addressService.setAddressValidity(canonicalAddresses));
+        }
+
+        @Test
+        void shouldThrowExceptionWhenGivenTwoInvalidAddresses() {
+
+            CanonicalAddress address0 = new CanonicalAddress();
+            address0.setValidFrom(null);
+            address0.setValidUntil(null);
+
+            CanonicalAddress address1 = new CanonicalAddress();
+            address1.setValidFrom(null);
+            address1.setValidUntil(null);
+
+            List<CanonicalAddress> canonicalAddresses = List.of(address0, address1);
+
+            AddressProcessingException exception =
+                    assertThrows(
+                            AddressProcessingException.class,
+                            () -> addressService.setAddressValidity(canonicalAddresses));
+
+            assertEquals(ERROR_COULD_NOT_DETERMINE_CURRENT_ADDRESS, exception.getMessage());
+        }
+
+        @Test
+        void shouldThrowExceptionWhenGivenTwoPreviousAddresses() {
+
+            LocalDate date = LocalDate.of(2013, 8, 9);
+
+            CanonicalAddress previousAddress0 = new CanonicalAddress();
+            previousAddress0.setValidFrom(date);
+            previousAddress0.setValidUntil(date.plusYears(1));
+
+            CanonicalAddress previousAddress1 = new CanonicalAddress();
+            previousAddress1.setValidFrom(date.plusYears(2));
+            previousAddress1.setValidUntil(date.plusYears(3));
+
+            List<CanonicalAddress> canonicalAddresses = List.of(previousAddress0, previousAddress1);
+
+            AddressProcessingException exception =
+                    assertThrows(
+                            AddressProcessingException.class,
+                            () -> addressService.setAddressValidity(canonicalAddresses));
+
+            assertEquals(ERROR_COULD_NOT_DETERMINE_CURRENT_ADDRESS, exception.getMessage());
+        }
+
+        @Test
+        void shouldSucceedWithTwoValidAddressesInReverseOrder() {
+
+            LocalDate date = LocalDate.of(2013, 8, 9);
+
+            CanonicalAddress currentAddress = new CanonicalAddress();
+            currentAddress.setValidFrom(date);
+
+            CanonicalAddress previousAddress = new CanonicalAddress();
+            previousAddress.setValidFrom(null);
+            previousAddress.setValidUntil(null);
+
+            assertNull(previousAddress.getValidUntil());
+
+            // Order Reversed
+            List<CanonicalAddress> canonicalAddresses = List.of(previousAddress, currentAddress);
+
+            assertDoesNotThrow(() -> addressService.setAddressValidity(canonicalAddresses));
+
+            // Linking performed
+            assertTrue(currentAddress.getValidFrom().isEqual(previousAddress.getValidUntil()));
+        }
+
+        @Test
+        void shouldThrowExceptionGivenInvalidFirstAddressDates() {
+
+            LocalDate date = LocalDate.of(2013, 8, 9);
+
+            CanonicalAddress address0 = new CanonicalAddress();
+            address0.setValidFrom(date);
+            address0.setValidUntil(date);
+
+            CanonicalAddress address1 = new CanonicalAddress();
+            address1.setValidFrom(date);
+            address1.setValidUntil(null);
+
+            List<CanonicalAddress> canonicalAddresses = List.of(address0, address1);
+
+            AddressProcessingException exception =
+                    assertThrows(
+                            AddressProcessingException.class,
+                            () -> addressService.setAddressValidity(canonicalAddresses));
+
+            assertEquals(ERROR_ADDRESS_DATE_IS_INVALID, exception.getMessage());
+        }
+
+        @Test
+        void shouldThrowExceptionWhenGivenInvalidSecondAddressDates() {
+
+            LocalDate date = LocalDate.of(2013, 8, 9);
+
+            CanonicalAddress address0 = new CanonicalAddress();
+            address0.setValidFrom(date);
+            address0.setValidUntil(null);
+
+            CanonicalAddress address1 = new CanonicalAddress();
+            address1.setValidFrom(date);
+            address1.setValidUntil(date);
+
+            // Reversed
+            List<CanonicalAddress> canonicalAddresses = List.of(address1, address0);
+
+            AddressProcessingException exception =
+                    assertThrows(
+                            AddressProcessingException.class,
+                            () -> addressService.setAddressValidity(canonicalAddresses));
+
+            assertEquals(ERROR_ADDRESS_DATE_IS_INVALID, exception.getMessage());
+        }
+
+        @Test
+        void shouldThrowExceptionWhenGivenThreeAddresses() {
+
+            LocalDate date = LocalDate.of(2013, 8, 9);
+
+            CanonicalAddress currentAddress = new CanonicalAddress();
+            currentAddress.setValidFrom(date);
+
+            CanonicalAddress previousAddress1 = new CanonicalAddress();
+            previousAddress1.setValidFrom(null);
+            previousAddress1.setValidUntil(null);
+
+            CanonicalAddress previousAddress2 = new CanonicalAddress();
+            previousAddress2.setValidFrom(null);
+            previousAddress2.setValidUntil(null);
+
+            List<CanonicalAddress> canonicalAddresses =
+                    List.of(currentAddress, previousAddress1, previousAddress2);
+
+            AddressProcessingException exception =
+                    assertThrows(
+                            AddressProcessingException.class,
+                            () -> addressService.setAddressValidity(canonicalAddresses));
+
+            assertEquals(ERROR_TOO_MANY_ADDRESSES, exception.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("Address Service is current Address")
+    class AddressServiceIsCurrentAddress {
+        @Test
+        void shouldReturnTrueWithExpectedCurrentFormatDates() {
+            CanonicalAddress address = new CanonicalAddress();
+            address.setValidFrom(LocalDate.now().minusYears(1));
+            address.setValidUntil(null);
+
+            assertTrue(addressService.isCurrentAddress(address));
+        }
+
+        @Test
+        void shouldReturnFalseWithExpectedPreviousFormatDates() {
+            CanonicalAddress address = new CanonicalAddress();
+            address.setValidFrom(null);
+            address.setValidUntil(LocalDate.now().minusYears(1));
+
+            assertFalse(addressService.isCurrentAddress(address));
+        }
+
+        @Test
+        void shouldReturnFalseWithExpectedInvalidFormatDates() {
+            CanonicalAddress address = new CanonicalAddress();
+            address.setValidFrom(LocalDate.now().minusYears(1));
+            address.setValidUntil(LocalDate.now().minusYears(1));
+
+            assertFalse(addressService.isCurrentAddress(address));
+        }
+    }
+
+    @Nested
+    @DisplayName("Address Service Is an InValid Address")
+    class AddressServiceIsInValidAddress {
+        @Test
+        void shouldReturnTrueWithInvalidFormatDates() {
+            CanonicalAddress address = new CanonicalAddress();
+            address.setValidFrom(LocalDate.now());
+            address.setValidUntil(LocalDate.now());
+
+            assertTrue(addressService.isInvalidAddress(address));
+        }
+
+        @Test
+        void shouldReturnFalseWithExpectedCurrentFormatDates() {
+            CanonicalAddress address = new CanonicalAddress();
+            address.setValidFrom(LocalDate.now().minusYears(1));
+            address.setValidUntil(null);
+
+            assertFalse(addressService.isInvalidAddress(address));
+        }
+
+        @Test
+        void shouldReturnFalseWhenGivenExpectedPreviousFormatDates() {
+            CanonicalAddress address = new CanonicalAddress();
+            address.setValidFrom(null);
+            address.setValidUntil(LocalDate.now().minusYears(1));
+
+            assertFalse(addressService.isInvalidAddress(address));
+        }
     }
 
     @Test
@@ -222,328 +589,78 @@ class AddressServiceTest {
         verify(mockDataStore).getItem(String.valueOf(SESSION_ID));
     }
 
-    @Test
-    void shouldSucceedWithNoAddresses() {
-        List<CanonicalAddress> canonicalAddresses = new ArrayList<>();
-        assertDoesNotThrow(() -> addressService.setAddressValidity(canonicalAddresses));
-    }
-
-    @Test
-    void shouldEvaluateToPreviousWithNULLNULL() {
-        // The reason for the linker existing is that a second address, intended as
-        // a PREVIOUS address has ValidFrom and ValidUntil not set - null,null. This however
-        // matches the pattern for a CURRENT address with unknown start date.
-        // In this specific case, we evaluate null, null as the intended PREVIOUS address.
-
-        CanonicalAddress currentAddress = new CanonicalAddress();
-        currentAddress.setValidFrom(null);
-        currentAddress.setValidUntil(null);
-
-        List<CanonicalAddress> canonicalAddresses = List.of(currentAddress);
-
-        AddressProcessingException exception =
-                assertThrows(
-                        AddressProcessingException.class,
-                        () -> addressService.setAddressValidity(canonicalAddresses));
-        assertEquals(ERROR_SINGLE_ADDRESS_NOT_CURRENT, exception.getMessage());
-    }
-
-    @Test
-    void shouldThrowExceptionWhenAboutToTrampleAlreadySetDates() {
-        // When AddressCRIFront is setting ValidUntil in previous addresses
-        // The linker can be removed entirely.
-
-        final LocalDate TEST_DATE_0 = LocalDate.of(1999, 12, 31);
-        final LocalDate TEST_DATE_1 = LocalDate.of(1999, 11, 30);
-
-        CanonicalAddress currentAddress = new CanonicalAddress();
-        currentAddress.setValidFrom(TEST_DATE_0);
-        currentAddress.setValidUntil(null);
-
-        CanonicalAddress previousAddress = new CanonicalAddress();
-        previousAddress.setValidFrom(null);
-        previousAddress.setValidUntil(TEST_DATE_1);
-
-        List<CanonicalAddress> canonicalAddresses = List.of(currentAddress, previousAddress);
-
-        AddressProcessingException exception =
-                assertThrows(
-                        AddressProcessingException.class,
-                        () -> addressService.setAddressValidity(canonicalAddresses));
-
-        assertEquals(ERROR_ADDRESS_LINKING_NOT_NEEDED, exception.getMessage());
-    }
-
-    @Test
-    void shouldSucceedWithSingleCurrentAddress() {
-
-        LocalDate date = LocalDate.of(2013, 8, 9);
-
-        CanonicalAddress currentAddress = new CanonicalAddress();
-        currentAddress.setValidFrom(date);
-
-        List<CanonicalAddress> canonicalAddresses = List.of(currentAddress);
-
-        assertDoesNotThrow(() -> addressService.setAddressValidity(canonicalAddresses));
-    }
-
-    @Test
-    void shouldThrowExceptionWhenGivenSingleInvalidAddress() {
-
-        CanonicalAddress currentAddress = new CanonicalAddress();
-        currentAddress.setValidFrom(null);
-        currentAddress.setValidUntil(null);
-
-        List<CanonicalAddress> canonicalAddresses = List.of(currentAddress);
-
-        AddressProcessingException exception =
-                assertThrows(
-                        AddressProcessingException.class,
-                        () -> addressService.setAddressValidity(canonicalAddresses));
-
-        assertEquals(ERROR_SINGLE_ADDRESS_NOT_CURRENT, exception.getMessage());
-    }
-
-    @Test
-    void shouldSucceedWithTwoValidAddresses() {
-
-        LocalDate date = LocalDate.of(2013, 8, 9);
-
-        CanonicalAddress currentAddress = new CanonicalAddress();
-        currentAddress.setValidFrom(date);
-
-        CanonicalAddress previousAddress = new CanonicalAddress();
-        previousAddress.setValidFrom(null);
-        previousAddress.setValidUntil(null);
-
-        assertNull(previousAddress.getValidUntil());
-
-        List<CanonicalAddress> canonicalAddresses = List.of(currentAddress, previousAddress);
-
-        assertDoesNotThrow(() -> addressService.setAddressValidity(canonicalAddresses));
-
-        // Linking performed
-        assertTrue(currentAddress.getValidFrom().isEqual(previousAddress.getValidUntil()));
-    }
-
-    @Test
-    void shouldSucceedWithTwoCurrentAddresses() {
-
-        LocalDate date = LocalDate.of(2013, 8, 9);
-
-        CanonicalAddress currentAddress0 = new CanonicalAddress();
-        currentAddress0.setValidFrom(date);
-
-        CanonicalAddress currentAddress1 = new CanonicalAddress();
-        currentAddress1.setValidFrom(date.plusYears(1));
-        currentAddress1.setValidUntil(null);
-
-        List<CanonicalAddress> canonicalAddresses = List.of(currentAddress0, currentAddress1);
-
-        assertDoesNotThrow(() -> addressService.setAddressValidity(canonicalAddresses));
-    }
-
-    @Test
-    void shouldThrowExceptionWhenGivenTwoInvalidAddresses() {
-
-        CanonicalAddress address0 = new CanonicalAddress();
-        address0.setValidFrom(null);
-        address0.setValidUntil(null);
-
-        CanonicalAddress address1 = new CanonicalAddress();
-        address1.setValidFrom(null);
-        address1.setValidUntil(null);
-
-        List<CanonicalAddress> canonicalAddresses = List.of(address0, address1);
-
-        AddressProcessingException exception =
-                assertThrows(
-                        AddressProcessingException.class,
-                        () -> addressService.setAddressValidity(canonicalAddresses));
-
-        assertEquals(ERROR_COULD_NOT_DETERMINE_CURRENT_ADDRESS, exception.getMessage());
-    }
-
-    @Test
-    void shouldThrowExceptionWhenGivenTwoPreviousAddresses() {
-
-        LocalDate date = LocalDate.of(2013, 8, 9);
-
-        CanonicalAddress previousAddress0 = new CanonicalAddress();
-        previousAddress0.setValidFrom(date);
-        previousAddress0.setValidUntil(date.plusYears(1));
-
-        CanonicalAddress previousAddress1 = new CanonicalAddress();
-        previousAddress1.setValidFrom(date.plusYears(2));
-        previousAddress1.setValidUntil(date.plusYears(3));
-
-        List<CanonicalAddress> canonicalAddresses = List.of(previousAddress0, previousAddress1);
-
-        AddressProcessingException exception =
-                assertThrows(
-                        AddressProcessingException.class,
-                        () -> addressService.setAddressValidity(canonicalAddresses));
-
-        assertEquals(ERROR_COULD_NOT_DETERMINE_CURRENT_ADDRESS, exception.getMessage());
-    }
-
-    @Test
-    void shouldSucceedWithTwoValidAddressesInReverseOrder() {
-
-        LocalDate date = LocalDate.of(2013, 8, 9);
-
-        CanonicalAddress currentAddress = new CanonicalAddress();
-        currentAddress.setValidFrom(date);
-
-        CanonicalAddress previousAddress = new CanonicalAddress();
-        previousAddress.setValidFrom(null);
-        previousAddress.setValidUntil(null);
-
-        assertNull(previousAddress.getValidUntil());
-
-        // Order Reversed
-        List<CanonicalAddress> canonicalAddresses = List.of(previousAddress, currentAddress);
-
-        assertDoesNotThrow(() -> addressService.setAddressValidity(canonicalAddresses));
-
-        // Linking performed
-        assertTrue(currentAddress.getValidFrom().isEqual(previousAddress.getValidUntil()));
-    }
-
-    @Test
-    void shouldThrowExceptionGivenInvalidFirstAddressDates() {
-
-        LocalDate date = LocalDate.of(2013, 8, 9);
-
-        CanonicalAddress address0 = new CanonicalAddress();
-        address0.setValidFrom(date);
-        address0.setValidUntil(date);
-
-        CanonicalAddress address1 = new CanonicalAddress();
-        address1.setValidFrom(date);
-        address1.setValidUntil(null);
-
-        List<CanonicalAddress> canonicalAddresses = List.of(address0, address1);
-
-        AddressProcessingException exception =
-                assertThrows(
-                        AddressProcessingException.class,
-                        () -> addressService.setAddressValidity(canonicalAddresses));
-
-        assertEquals(ERROR_ADDRESS_DATE_IS_INVALID, exception.getMessage());
-    }
-
-    @Test
-    void shouldThrowExceptionWhenGivenInvalidSecondAddressDates() {
-
-        LocalDate date = LocalDate.of(2013, 8, 9);
-
-        CanonicalAddress address0 = new CanonicalAddress();
-        address0.setValidFrom(date);
-        address0.setValidUntil(null);
-
-        CanonicalAddress address1 = new CanonicalAddress();
-        address1.setValidFrom(date);
-        address1.setValidUntil(date);
-
-        // Reversed
-        List<CanonicalAddress> canonicalAddresses = List.of(address1, address0);
-
-        AddressProcessingException exception =
-                assertThrows(
-                        AddressProcessingException.class,
-                        () -> addressService.setAddressValidity(canonicalAddresses));
-
-        assertEquals(ERROR_ADDRESS_DATE_IS_INVALID, exception.getMessage());
-    }
-
-    @Test
-    void shouldThrowExceptionWhenGivenThreeAddresses() {
-
-        LocalDate date = LocalDate.of(2013, 8, 9);
-
-        CanonicalAddress currentAddress = new CanonicalAddress();
-        currentAddress.setValidFrom(date);
-
-        CanonicalAddress previousAddress1 = new CanonicalAddress();
-        previousAddress1.setValidFrom(null);
-        previousAddress1.setValidUntil(null);
-
-        CanonicalAddress previousAddress2 = new CanonicalAddress();
-        previousAddress2.setValidFrom(null);
-        previousAddress2.setValidUntil(null);
-
-        List<CanonicalAddress> canonicalAddresses =
-                List.of(currentAddress, previousAddress1, previousAddress2);
-
-        AddressProcessingException exception =
-                assertThrows(
-                        AddressProcessingException.class,
-                        () -> addressService.setAddressValidity(canonicalAddresses));
-
-        assertEquals(ERROR_TOO_MANY_ADDRESSES, exception.getMessage());
-    }
-
-    @Test
-    void shouldReturnTrueWithExpectedCurrentFormatDates() {
-        CanonicalAddress address = new CanonicalAddress();
-        address.setValidFrom(LocalDate.now().minusYears(1));
-        address.setValidUntil(null);
-
-        assertTrue(addressService.isCurrentAddress(address));
-    }
-
-    @Test
-    void shouldReturnFalseWithExpectedPreviousFormatDates() {
-        CanonicalAddress address = new CanonicalAddress();
-        address.setValidFrom(null);
-        address.setValidUntil(LocalDate.now().minusYears(1));
-
-        assertFalse(addressService.isCurrentAddress(address));
-    }
-
-    @Test
-    void shouldReturnFalseWithExpectedInvalidFormatDates() {
-        CanonicalAddress address = new CanonicalAddress();
-        address.setValidFrom(LocalDate.now().minusYears(1));
-        address.setValidUntil(LocalDate.now().minusYears(1));
-
-        assertFalse(addressService.isCurrentAddress(address));
-    }
-
-    @Test
-    void shouldReturnTrueWithNULLNULLFormatDates() {
-        CanonicalAddress address = new CanonicalAddress();
-        address.setValidFrom(null);
-        address.setValidUntil(null);
-
-        assertTrue(addressService.isNotCurrentAddress(address));
-    }
-
-    @Test
-    void shouldReturnTrueWithInvalidFormatDates() {
-        CanonicalAddress address = new CanonicalAddress();
-        address.setValidFrom(LocalDate.now());
-        address.setValidUntil(LocalDate.now());
-
-        assertTrue(addressService.isInvalidAddress(address));
-    }
-
-    @Test
-    void shouldReturnFalseWithExpectedCurrentFormatDates() {
-        CanonicalAddress address = new CanonicalAddress();
-        address.setValidFrom(LocalDate.now().minusYears(1));
-        address.setValidUntil(null);
-
-        assertFalse(addressService.isInvalidAddress(address));
-    }
-
-    @Test
-    void shouldReturnFalseWhenGivenExpectedPreviousFormatDates() {
-        CanonicalAddress address = new CanonicalAddress();
-        address.setValidFrom(null);
-        address.setValidUntil(LocalDate.now().minusYears(1));
-
-        assertFalse(addressService.isInvalidAddress(address));
+    @Nested
+    @DisplayName("Address Service maps canonical addresses to addresses")
+    class AddressServiceMapCanonicalAddresses {
+        @Test
+        void shouldNotErrorWhenMappingCanonicalAddresesOnEmptyInput() {
+            assertDoesNotThrow(() -> addressService.mapCanonicalAddresses(Collections.emptyList()));
+        }
+
+        @Test
+        void shouldMapCanonicalAddressesToAddresses() {
+            CanonicalAddress address = new CanonicalAddress();
+            address.setBuildingNumber("buildingNum");
+            address.setStreetName("street");
+            address.setPostalCode("postcode");
+
+            CanonicalAddress previousAddress = new CanonicalAddress();
+            previousAddress.setBuildingNumber("buildingNum");
+            previousAddress.setStreetName("street");
+            previousAddress.setPostalCode("postcode");
+
+            List<Address> mappedAddresses =
+                    addressService.mapCanonicalAddresses(List.of(address, previousAddress));
+            mappedAddresses.forEach(
+                    mappedAddress -> {
+                        assertAll(
+                                () -> {
+                                    assertEquals(
+                                            address.getAddressCountry(),
+                                            mappedAddress.getAddressCountry());
+                                    assertEquals(
+                                            address.getAddressLocality(),
+                                            mappedAddress.getAddressLocality());
+                                    assertEquals(
+                                            address.getDependentAddressLocality(),
+                                            mappedAddress.getDependentAddressLocality());
+                                    assertEquals(
+                                            address.getBuildingName(),
+                                            mappedAddress.getBuildingName());
+                                    assertEquals(
+                                            address.getDepartmentName(),
+                                            mappedAddress.getDepartmentName());
+                                    assertEquals(
+                                            address.getBuildingNumber(),
+                                            mappedAddress.getBuildingNumber());
+                                    assertEquals(
+                                            address.getDependentStreetName(),
+                                            mappedAddress.getDependentStreetName());
+                                    assertEquals(
+                                            address.getDoubleDependentAddressLocality(),
+                                            mappedAddress.getDoubleDependentAddressLocality());
+                                    assertEquals(
+                                            address.getOrganisationName(),
+                                            mappedAddress.getOrganisationName());
+                                    assertEquals(
+                                            address.getStreetName(), mappedAddress.getStreetName());
+                                    assertEquals(
+                                            address.getSubBuildingName(),
+                                            mappedAddress.getSubBuildingName());
+                                    assertEquals(address.getUprn(), mappedAddress.getUprn());
+                                    assertEquals(
+                                            address.getPostalCode(), mappedAddress.getPostalCode());
+                                });
+                    });
+        }
+
+        @Test
+        void shouldReturnTrueWithNULLNULLFormatDates() {
+            CanonicalAddress address = new CanonicalAddress();
+            address.setValidFrom(null);
+            address.setValidUntil(null);
+
+            assertTrue(addressService.isNotCurrentAddress(address));
+        }
     }
 }


### PR DESCRIPTION
## Requires:
https://github.com/govuk-one-login/ipv-cri-lib/pull/400

## Proposed changes

This work is in support of https://govukverify.atlassian.net/browse/DCP-1590 

Modify  event IPV_ADDRESS_VC_ISSUED to capture actual address fields

The address should be mapped into the restricted.address field on the IPV_ADDRESS_VC_ISSUED TXMA Event. The address object is an array of addresses and should be mapped as such.

### Why did it change

In order to have consistency across for events for VC Structures, add actual address fields as part of the event as this information needs to be sent downstream to Relying parties. This information will also held the TICF team with their analysis instead of them getting the address for the journey across different events

**Before:**

```
{
    "timestamp": 1685334001,
    "event_name": "IPV_ADDRESS_CRI_VC_ISSUED",
    "component_id": "https://review-a.dev.account.gov.uk"/,
    "user": {
        "user_id": "urn:fdc:gov.uk:2022:09f5a28c-02db-4b10-adca-9f23614da942",
        "ip_address": "XX.XXX.XXX.XX",
        "session_id": "864b587a-7103-4cfb-9183-9c46323d676c",
        "persistent_session_id": "a1c4810a-d60e-4634-af5c-48d2159c1eea",
        "govuk_signin_journey_id": "f3bcc04d-e271-433f-8a7c-73318f82c6b1"
    },
    "extensions": {
        "iss": "https://review-a.dev.account.gov.uk"/,
        "addressesEntered": 1
    }
}
```

**After:**

```
{
  "timestamp": 1707404562,
  "event_name": "IPV_ADDRESS_CRI_VC_ISSUED",
  "component_id": "https://review-a.dev.account.gov.uk",
  "restricted": {
    "address": [
      {
        "uprn": 100120012077,
        "subBuildingName": "",
        "buildingNumber": "8",
        "buildingName": "",
        "streetName": "SOME ROAD",
        "addressLocality": "BATH",
        "postalCode": "PO BOX",
        "addressCountry": "GB",
        "validFrom": "2019-01-01"
      }
    ]
  },
  "user": {
    "user_id": "urn:fdc:gov.uk:2022:4cd8b63b-ddad-4f40-bc31-67e8fe1a2d16",
    "ip_address": "XX.XXX.X.XX",
    "session_id": "102fc019-0660-4568-9d78-1fb5aeeeb432",
    "persistent_session_id": "3cf8bf26-591d-4174-b0e0-965df18c07a4",
    "govuk_signin_journey_id": "375b264a-7c8b-40a8-bc78-a3e145c0a78b"
  },
  "extensions": {
    "iss": "https://review-a.dev.account.gov.uk",
    "addressesEntered": 1
  }
}

```


- [OJ-2240](https://govukverify.atlassian.net/browse/OJ-2240)



[OJ-2240]: https://govukverify.atlassian.net/browse/OJ-2240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ