### PR TITLE
OJ-2283: Updated cri_common_lib version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "1.5.5"
+		cri_common_lib           : "1.5.6"
 	]
 }
 


### PR DESCRIPTION
## Proposed changes

### What changed
cri_common_lib to version 1.5.6

### Why did it change
event_timestamp_ms related changes.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2283](https://govukverify.atlassian.net/browse/OJ-2283)


[OJ-2283]: https://govukverify.atlassian.net/browse/OJ-2283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ