### PR TITLE
OJ-2545: Add CloudFront header tests

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -27,11 +27,15 @@ jobs:
     name: Run tests
     needs: deploy
     uses: ./.github/workflows/run-integration-tests.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       aws-region: ${{ needs.deploy.outputs.aws-region }}
       stack-name: ${{ needs.deploy.outputs.stack-name }}
       stack-outputs: ${{ needs.deploy.outputs.stack-outputs }}
     secrets:
+      aws_role_arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
       api-gateway-api-key: ${{ secrets.APIGW_API_KEY }}
       ipv-core-stub-basic-auth-user: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_USER }}
       ipv-core-stub-basic-auth-pwd: ${{ secrets.IPV_CORE_STUB_BASIC_AUTH_PASSWORD }}

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 7.4.2
 

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -36,7 +36,7 @@ jobs:
           version: 1.74.0
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 7.4.2
 

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -36,7 +36,7 @@ jobs:
           version: 1.74.0
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 7.4.2
 

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -15,8 +15,8 @@ on:
 permissions: {}
 
 concurrency:
-  group: integration-tests-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+  group: integration-tests
+  cancel-in-progress: false
 
 jobs:
   run-tests:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -3,10 +3,11 @@ name: Integration tests
 on:
   workflow_call:
     inputs:
-      aws-region: { required: false, type: string }
+      aws-region: { required: true, type: string }
       stack-name: { required: true, type: string }
       stack-outputs: { required: true, type: string }
     secrets:
+      aws_role_arn: { required: true }
       api-gateway-api-key: { required: true }
       ipv-core-stub-basic-auth-pwd: { required: true }
       ipv-core-stub-basic-auth-user: { required: true }
@@ -23,6 +24,9 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     environment: di-ipv-cri-dev
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Pull repository
         uses: actions/checkout@v4
@@ -31,6 +35,12 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.4.2
+
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws_role_arn }}
+          aws-region: ${{ inputs.aws-region }}
 
       - name: Run tests
         env:
@@ -45,4 +55,4 @@ jobs:
           IPV_CORE_STUB_CRI_ID: address-cri-dev
           DEFAULT_CLIENT_ID: ipv-core-stub-aws-build
           APIGW_API_KEY: ${{ secrets.api-gateway-api-key }}
-        run: ./gradlew integration-tests:cucumber
+        run: ./gradlew --no-daemon integration-tests:cucumber

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 7.4.2
 

--- a/.github/workflows/run-unit-tests-java.yml
+++ b/.github/workflows/run-unit-tests-java.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 7.4.2
 

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           gradle-version: 7.4.2
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "1.6.1"
+		cri_common_lib           : "2.1.0"
 	]
 }
 
@@ -66,7 +66,7 @@ subprojects {
 	}
 
 	dependencies {
-		aws platform('software.amazon.awssdk:bom:2.17.191')
+		aws platform('software.amazon.awssdk:bom:2.20.162')
 
 		dynamodb "software.amazon.awssdk:dynamodb",
 				"software.amazon.awssdk:dynamodb-enhanced"

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,5 +32,6 @@ sam deploy --stack-name "$stack_name" \
   --parameter-overrides \
   Environment=dev \
   CodeSigningEnabled=false \
+  SecretPrefix=pre-merge-test \
   ${common_stack_name:+CommonStackName=$common_stack_name} \
   ${secret_prefix:+SecretPrefix=$secret_prefix}

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,7 +31,6 @@ sam deploy --stack-name "$stack_name" \
   cri:deployment-source=manual \
   --parameter-overrides \
   Environment=dev \
-  CodeSigningEnabled=false \
   SecretPrefix=pre-merge-test \
   ${common_stack_name:+CommonStackName=$common_stack_name} \
   ${secret_prefix:+SecretPrefix=$secret_prefix}

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -3,9 +3,6 @@ Transform: "AWS::Serverless-2016-10-31"
 Description: "Digital Identity IPV CRI Address API"
 
 Parameters:
-  CodeSigningEnabled:
-    Type: "String"
-    Default: "true"
   CodeSigningConfigArn:
     Type: String
     Default: "none"
@@ -26,9 +23,9 @@ Parameters:
     Type: String
     Default: "none"
   SecretPrefix:
+    Description: Secrets name prefix
     Type: String
     Default: "none"
-    Description: Secrets name prefix
   AuditEventNamePrefix:
     Description: "The audit event name prefix"
     Type: AWS::SSM::Parameter::Value<String>
@@ -40,33 +37,19 @@ Parameters:
   CommonStackName:
     Description: "The name of the stack containing the common CRI lambdas/infra"
     Type: String
-    Default: "common-cri-api"
+    Default: common-cri-api
+  TxmaStackName:
+    Description: "The stack containing the TXMA infrastructure"
+    Type: String
+    Default: txma-infrastructure
 
 Conditions:
-  EnforceCodeSigning: !Equals
-    - !Ref  CodeSigningEnabled
-    - true
-  CreateDevResources: !Equals
-    - !Ref Environment
-    - dev
-  IsProdEnvironment: !Equals
-    - !Ref Environment
-    - production
-  IsDevEnvironment: !Equals
-    - !Ref Environment
-    - dev
-  IsNotDevEnvironment: !Not
-    - Condition: IsDevEnvironment
-  UsePermissionsBoundary:
-    Fn::Not:
-      - Fn::Equals:
-          - !Ref PermissionsBoundary
-          - "none"
-  UseSecretPrefix:
-    Fn::Not:
-      - Fn::Equals:
-          - !Ref SecretPrefix
-          - "none"
+  UseCodeSigningConfig: !Not [!Equals [!Ref CodeSigningConfigArn, "none"]]
+  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, "none"]]
+  IsDevEnvironment: !Equals [!Ref Environment, dev]
+  IsProdEnvironment: !Equals [!Ref Environment, production]
+  IsNotDevEnvironment: !Not [!Condition IsDevEnvironment]
+  UseSecretPrefix: !Not [!Equals [!Ref SecretPrefix, "none"]]
   AddProvisionedConcurrency: !Not
     - !Equals
       - !FindInMap [ EnvironmentConfiguration, !Ref Environment, provisionedConcurrency ]
@@ -83,7 +66,7 @@ Globals:
       - !Ref PermissionsBoundary
       - !Ref AWS::NoValue
     CodeSigningConfigArn: !If
-      - EnforceCodeSigning
+      - UseCodeSigningConfig
       - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
     Timeout: 30 # seconds
@@ -294,7 +277,7 @@ Resources:
               Condition:
                 StringNotEquals:
                   aws:SourceVpce: !If
-                    - CreateDevResources
+                    - IsDevEnvironment
                     - vpce-082cab7c78139eb54
                     - !ImportValue cri-vpc-ApiGatewayVpcEndpointId
 
@@ -386,7 +369,8 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-postcode-lookup"
-          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+          SQS_AUDIT_EVENT_QUEUE_URL:
+            Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -421,15 +405,16 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
         - SQSSendMessagePolicy:
-            QueueName: !ImportValue AuditEventQueueName
+            QueueName:
+              Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueName
         - Statement:
             - Sid: auditEventQueueKmsEncryptionKeyPermission
               Effect: Allow
               Action:
-                - 'kms:Decrypt'
-                - 'kms:GenerateDataKey'
+                - kms:Decrypt
+                - kms:GenerateDataKey
               Resource:
-                - !ImportValue AuditEventQueueEncryptionKeyArn
+                Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueEncryptionKeyArn
 
   PostcodeLookupFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -498,7 +483,8 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-issuecredential"
-          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+          SQS_AUDIT_EVENT_QUEUE_URL:
+            Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
@@ -512,7 +498,8 @@ Resources:
               - "kms:Sign"
             Resource: !ImportValue core-infrastructure-CriVcSigningKey1Arn
         - SQSSendMessagePolicy:
-            QueueName: !ImportValue AuditEventQueueName
+            QueueName:
+              Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueName
         - Statement:
             Effect: Allow
             Action:
@@ -532,8 +519,7 @@ Resources:
               - kms:Decrypt
               - kms:GenerateDataKey
             Resource:
-              - !ImportValue AuditEventQueueEncryptionKeyArn
-
+              Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueEncryptionKeyArn
   IssueCredentialFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
@@ -609,8 +595,7 @@ Resources:
   PublicAddressApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
     Condition: IsNotDevEnvironment
-    DependsOn:
-      - PublicAddressApiStage
+    DependsOn: PublicAddressApiStage
     Properties:
       ApiStages:
         - ApiId: !Ref PublicAddressApi
@@ -625,8 +610,7 @@ Resources:
   PrivateAddressApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
     Condition: IsNotDevEnvironment
-    DependsOn:
-      - PrivateAddressApiStage
+    DependsOn: PrivateAddressApiStage
     Properties:
       ApiStages:
         - ApiId: !Ref PrivateAddressApi
@@ -796,11 +780,6 @@ Resources:
             Stat: Sum
 
 Outputs:
-
-  StackName:
-    Description: "CloudFormation stack name"
-    Value: !Sub "${AWS::StackName}"
-
   AddressApiGatewayId:
     Description: "API GatewayID of the Address CRI API"
     Value: !Sub "${PublicAddressApi}"

--- a/integration-tests/src/test/resources/features/AddressAPIHappyPath.feature
+++ b/integration-tests/src/test/resources/features/AddressAPIHappyPath.feature
@@ -1,32 +1,68 @@
 Feature: Address API happy path test
 
+  @address_api_happy_with_header
+  Scenario: Basic Address API journey with TXMA event header
+    Given user has the test-identity 197 in the form of a signed JWT string
+
+    # Session
+    When user sends a POST request to session end point with txma header
+    Then user gets a session-id
+
+    # TXMA event
+    Then TXMA event is added to the SQS queue containing device information header
+
+    # Postcode lookup
+    When the user performs a postcode lookup for post code "SW1A 2AA"
+    Then user receives a list of addresses containing "SW1A 2AA"
+
+    # Address
+    When the user selects address
+    Then the address is saved successfully
+
+    # Authorization
+    When user sends a GET request to authorization end point
+    And a valid authorization code is returned in the response
+
+    # Access Token
+    When user sends a POST request to token end point
+    And a valid access token code is returned in the response
+
+    #Credential issued
+    When user sends a POST request to Credential Issue end point with a valid access token
+    And a valid JWT is returned in the response
+    And 5 events are deleted from the audit events SQS queue
+
   @address_api_happy
   Scenario Outline: Basic Address API journey
     Given user has the test-identity <testUserDataSheetRowNumber> in the form of a signed JWT string
 
-    #Session
+    # Session
     When user sends a POST request to session end point
     Then user gets a session-id
 
-    #Postcode Lookup
+    # TXMA event
+    Then TXMA event is added to the SQS queue not containing device information header
+
+    # Postcode lookup
     When the user performs a postcode lookup for post code "<testPostCode>"
     Then user receives a list of addresses containing "<testPostCode>"
 
-    #Address
+    # Address
     When the user selects address
     Then the address is saved successfully
 
-    #Authorization
+    # Authorization
     When user sends a GET request to authorization end point
     And a valid authorization code is returned in the response
 
-    #Access Token
+    # Access token
     When user sends a POST request to token end point
     And a valid access token code is returned in the response
 
-    #Credential Issue
+    # Credential Issued
     When user sends a POST request to Credential Issue end point with a valid access token
     And a valid JWT is returned in the response
+    And 5 events are deleted from the audit events SQS queue
 
     Examples:
       | testUserDataSheetRowNumber | testPostCode |

--- a/integration-tests/src/test/resources/features/InvalidPostcodeTest.feature
+++ b/integration-tests/src/test/resources/features/InvalidPostcodeTest.feature
@@ -4,13 +4,16 @@ Feature: Invalid postcode test
   Scenario Outline: Invalid postcode
     Given user has the test-identity <testUserDataSheetRowNumber> in the form of a signed JWT string
 
-    #Session
+    # Session
     When user sends a POST request to session end point
     Then user gets a session-id
 
-    #Postcode Lookup
+    # Postcode lookup
     When the user performs a postcode lookup for post code "<testPostCode>"
     Then user does not get any address
+
+    # TxMA events
+    And 3 events are deleted from the audit events SQS queue
 
     Examples:
       | testUserDataSheetRowNumber | testPostCode |


### PR DESCRIPTION
**OJ-2545: Add CloudFront integration tests**

**Tests**
- Check for the device information header in the CRI start message
- Use the SQS and CloudFormation helpers from common-lib
- Update GHA to run the new integration tests
   Run integration tests sequentially between PRs to avoid SQS concurrency issues.
- Use `JsonPointer` to make assertions for JSON objects
- Upgrade the version of the common-lib to get the SQS and CF helper
  Update the AWS SDK version to match.

**Fixes**
- Use prefixed TxMA exports
  The non-prefixed exports are deprecated and will be removed in the future.
- Use the correct secret prefix for local developer stacks