### PR TITLE
OJ-2292: Fix no such field error linked to INCIDEN-751 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,6 @@ subprojects {
 		dynamodb "software.amazon.awssdk:dynamodb",
 				"software.amazon.awssdk:dynamodb-enhanced"
 
-		gson "com.google.code.gson:gson:2.8.9"
-
 		lambda "software.amazon.awssdk:lambda",
 				"com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ ext {
 	dependencyVersions = [
 		jackson_version          : "2.13.1",
 		aws_lambda_events_version: "3.11.0",
-		nimbusds_oauth_version   : "9.25",
-		nimbusds_jwt_version     : "9.15.1",
+		nimbusds_oauth_version   :  "11.2",
+		nimbusds_jwt_version	 : 	"9.36",
 		protobuf_version         : "3.19.4",
 		junit                    : "5.10.2",
 		mockito                  : "4.3.1",

--- a/lambdas/postcode-lookup/build.gradle
+++ b/lambdas/postcode-lookup/build.gradle
@@ -8,7 +8,6 @@ dependencies {
 	implementation configurations.cri_common_lib,
 			configurations.aws,
 			configurations.lambda,
-			configurations.gson,
 			configurations.nimbus
 
 	aspect configurations.powertools

--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupService.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupService.java
@@ -2,7 +2,6 @@ package uk.gov.di.ipv.cri.address.api.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.oauth2.sdk.util.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.http.HttpStatusCode;
@@ -68,7 +67,7 @@ public class PostcodeLookupService {
             throws PostcodeLookupValidationException, PostcodeLookupProcessingException,
                     JsonProcessingException, PostcodeLookupBadRequestException {
         // Check the postcode is valid
-        if (StringUtils.isBlank(postcode)) {
+        if (isBlank(postcode)) {
             throw new PostcodeLookupValidationException("Postcode cannot be null or empty");
         }
         // Create our http request
@@ -93,7 +92,7 @@ public class PostcodeLookupService {
         Objects.requireNonNull(requestHeaders, "requestHeaders must not be null");
         Objects.requireNonNull(sessionItem, "sessionItem must not be null");
 
-        if (StringUtils.isBlank(postcode)) {
+        if (isBlank(postcode)) {
             throw new IllegalArgumentException("postcode must not be null or blank");
         }
 
@@ -165,9 +164,8 @@ public class PostcodeLookupService {
     }
 
     private HttpResponse<String> sendHttpRequest(HttpRequest request) {
-        HttpResponse<String> response;
         try {
-            response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            return client.send(request, HttpResponse.BodyHandlers.ofString());
         } catch (HttpConnectTimeoutException e) {
             log.error("Postcode lookup threw HTTP connection timeout exception", e);
             throw new PostcodeLookupTimeoutException(
@@ -184,7 +182,6 @@ public class PostcodeLookupService {
             throw new PostcodeLookupProcessingException(
                     "Error sending request for postcode lookup", e);
         }
-        return response;
     }
 
     private HttpRequest createHttpRequest(String postcode)
@@ -222,5 +219,9 @@ public class PostcodeLookupService {
                 .version(HttpClient.Version.HTTP_2)
                 .connectTimeout(Duration.ofSeconds(CONNECTION_TIMEOUT_SECONDS))
                 .build();
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
+++ b/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
@@ -94,6 +94,25 @@ class PostcodeLookupServiceTest {
         }
 
         @Test
+        @DisplayName(
+                "it should throw Error due to library incompatibility issues. check project build configuration"
+                        + "and ipv-cri-lib dependencies for version mismatches")
+        void noSuchFieldErrorThrowsProcessingException() throws IOException, InterruptedException {
+            // Mock a valid url so service doesn't fall over validating URI
+            when(mockConfigurationService.getParameterValue("OrdnanceSurveyAPIURL"))
+                    .thenReturn("http://localhost:8080/");
+
+            // Simulate Http Client IO Failure
+            when(httpClient.send(
+                            any(HttpRequest.class),
+                            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+                    .thenThrow(NoSuchFieldError.class);
+            assertThrows(
+                    PostcodeLookupProcessingException.class,
+                    () -> postcodeLookupService.lookupPostcode("ZZ1 1ZZ"));
+        }
+
+        @Test
         void ioExceptionThrowsProcessingException() throws IOException, InterruptedException {
             // Mock a valid url so service doesn't fall over validating URI
             when(mockConfigurationService.getParameterValue("OrdnanceSurveyAPIURL"))


### PR DESCRIPTION
## Proposed changes

see: https://govukverify.atlassian.net/browse/INCIDEN-751

**NoSuchFieldError** error usually happens due to library incompatibilty changes
https://docs.oracle.com/javase%2F7%2Fdocs%2Fapi%2F%2F/java/lang/NoSuchFieldError.html
java.lang.NoSuchFieldError began when [ipv-cri-lib](https://github.com/govuk-one-login/ipv-cri-lib/pull/335) was updated
and address-cri nimbus libraries became out of sync see below

see: https://gds.splunkcloud.com/en-GB/app/gds-050-digital-Identity/search?earliest=&latest=1703940074.433&q=search%20index%3D%22gds_di_production%22%20address-cri-api-v1-PostcodeLookupFunction*%20NoSuchFieldError&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=standard_perf&display.events.type=list&sid=1718321180.264455
