### PR TITLE
OJ-2647: Rename postcode_error_lookup metric dimension

### DIFF
--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
@@ -56,6 +56,8 @@ public class PostcodeLookupHandler
     protected static final String SESSION_ID = "session_id";
     protected static final String LAMBDA_NAME = "postcode_lookup";
     protected static final String POSTCODE_ERROR = "postcode_lookup_error";
+    protected static final String POSTCODE_ERROR_TYPE = "postcode_lookup_error_type";
+    protected static final String POSTCODE_ERROR_MESSAGE = "postcode_lookup_error_message";
 
     @ExcludeFromGeneratedCoverageReport
     public PostcodeLookupHandler() {
@@ -126,10 +128,11 @@ public class PostcodeLookupHandler
     private APIGatewayProxyResponseEvent handleException(
             Exception e, ErrorObject oauth2ErrorType, String message, int statusCode) {
         String[] formatMessage = message.toLowerCase().split(" ");
-        String metricName = Arrays.stream(formatMessage).collect(Collectors.joining("_"));
+        String errorName = Arrays.stream(formatMessage).collect(Collectors.joining("_"));
 
         eventProbe.log(Level.ERROR, e).counterMetric(POSTCODE_ERROR);
-        eventProbe.addDimensions(Map.of(metricName, e.getMessage()));
+        eventProbe.addDimensions(
+                Map.of(POSTCODE_ERROR_TYPE, errorName, POSTCODE_ERROR_MESSAGE, e.getMessage()));
 
         if (Objects.nonNull(oauth2ErrorType)) {
             return ApiGatewayResponseGenerator.proxyJsonResponse(

--- a/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHanderTest.java
+++ b/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHanderTest.java
@@ -47,6 +47,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.address.api.handler.PostcodeLookupHandler.LAMBDA_NAME;
 import static uk.gov.di.ipv.cri.address.api.handler.PostcodeLookupHandler.POSTCODE_ERROR;
+import static uk.gov.di.ipv.cri.address.api.handler.PostcodeLookupHandler.POSTCODE_ERROR_MESSAGE;
+import static uk.gov.di.ipv.cri.address.api.handler.PostcodeLookupHandler.POSTCODE_ERROR_TYPE;
 import static uk.gov.di.ipv.cri.address.api.handler.PostcodeLookupHandler.SESSION_ID;
 
 @ExtendWith(MockitoExtension.class)
@@ -83,7 +85,13 @@ class PostcodeLookupHanderTest {
         verifyErrorsLoggedByEventProbe(exception);
         verifyNoMoreInteractions(eventProbe);
 
-        assertEquals(Map.of("invalid_postcode_param", "Postcode is empty"), capturedDimension);
+        assertEquals(
+                Map.of(
+                        POSTCODE_ERROR_TYPE,
+                        "invalid_postcode_param",
+                        POSTCODE_ERROR_MESSAGE,
+                        "Postcode is empty"),
+                capturedDimension);
         assertEquals(HttpStatusCode.BAD_REQUEST, responseEvent.getStatusCode());
         assertEquals("\"Postcode is empty\"", responseEvent.getBody());
     }
@@ -112,7 +120,13 @@ class PostcodeLookupHanderTest {
         verifyErrorsLoggedByEventProbe(sessionNotFoundException);
         verifyNoMoreInteractions(eventProbe);
 
-        assertEquals(Map.of("session_not_found", "Session not found"), capturedDimension);
+        assertEquals(
+                Map.of(
+                        POSTCODE_ERROR_TYPE,
+                        "session_not_found",
+                        POSTCODE_ERROR_MESSAGE,
+                        "Session not found"),
+                capturedDimension);
         assertEquals(HttpStatusCode.FORBIDDEN, responseEvent.getStatusCode());
         assertEquals(
                 "{\"error_description\":\"Access denied by resource owner or authorization server - Session not found\",\"error\":\"access_denied\"}",
@@ -143,7 +157,13 @@ class PostcodeLookupHanderTest {
         verifyErrorsLoggedByEventProbe(sessionExpiredException);
         verifyNoMoreInteractions(eventProbe);
 
-        assertEquals(Map.of("session_expired", "session expired"), capturedDimension);
+        assertEquals(
+                Map.of(
+                        POSTCODE_ERROR_TYPE,
+                        "session_expired",
+                        POSTCODE_ERROR_MESSAGE,
+                        "session expired"),
+                capturedDimension);
         assertEquals(HttpStatusCode.FORBIDDEN, responseEvent.getStatusCode());
         assertEquals(
                 "{\"error_description\":\"Access denied by resource owner or authorization server - Session expired\",\"error\":\"access_denied\"}",
@@ -172,7 +192,13 @@ class PostcodeLookupHanderTest {
 
         verifyErrorsLoggedByEventProbe(exception);
         verifyNoMoreInteractions(eventProbe);
-        assertEquals(Map.of("lookup_server", "Any other exception"), dimension);
+        assertEquals(
+                Map.of(
+                        POSTCODE_ERROR_TYPE,
+                        "lookup_server",
+                        POSTCODE_ERROR_MESSAGE,
+                        "Any other exception"),
+                dimension);
         assertEquals(HttpStatusCode.UNAUTHORIZED, responseEvent.getStatusCode());
         assertEquals("\"Any other exception\"", responseEvent.getBody().toString());
     }
@@ -211,7 +237,13 @@ class PostcodeLookupHanderTest {
         verifyNoMoreInteractions(eventProbe);
 
         assertEquals(HttpStatusCode.REQUEST_TIMEOUT, responseEvent.getStatusCode());
-        assertEquals(Map.of("time_out_error", "Error Connection Timeout"), dimension);
+        assertEquals(
+                Map.of(
+                        POSTCODE_ERROR_TYPE,
+                        "time_out_error",
+                        POSTCODE_ERROR_MESSAGE,
+                        "Error Connection Timeout"),
+                dimension);
         assertEquals("\"Error Connection Timeout\"", responseEvent.getBody().toString());
     }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Rename postcode_error_lookup metric dimension names to be the same for all errors so we can display it in Dynatrace.
Now called postcode_lookup_error_type and postcode_lookup_error_message

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
Unless the exception had been thrown the metric had not been created in prod/non-prod so we could not create a daashboard in Dynatrace. Giving all the errors dimensions names the same value means we can then filter on the value rather than the key. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2647](https://govukverify.atlassian.net/browse/OJ-2647)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2647]: https://govukverify.atlassian.net/browse/OJ-2647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ