### PR TITLE
OJ-2650: Address pact vc

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -113,6 +117,7 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_secret",
       "pattern": [
+        "ZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKRlV6STFOaUo5LmV5SnBjM01pT2lKa2RXMXRlVUZrWkhKbGMzTkRiMjF3YjI1bGJuUkpaQ0lzSW5OMVlpSTZJblJsYzNRdGMzVmlhbVZqZENJc0ltNWlaaUk2TkRBM01Ea3dPRGd3TUN3aVpYaHdJam8wTURjd09UQTVOREF3TENKMll5STZleUowZVhCbElqcGJJbFpsY21sbWFXRmliR1ZEY21Wa1pXNTBhV0ZzSWl3aVFXUmtjbVZ6YzBOeVpXUmxiblJwWVd3aVhTd2lRR052Ym5SbGVIUWlPbHNpYUhSMGNITTZMeTkzZDNjdWR6TXViM0puTHpJd01UZ3ZZM0psWkdWdWRHbGhiSE12ZGpFaUxDSm9kSFJ3Y3pvdkwzWnZZMkZpTG1GalkyOTFiblF1WjI5MkxuVnJMMk52Ym5SbGVIUnpMMmxrWlc1MGFYUjVMWFl4TG1wemIyNXNaQ0pkTENKamNtVmtaVzUwYVdGc1UzVmlhbVZqZENJNmV5SmhaR1J5WlhOeklqcGJleUp*",
         "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgOXt0P05ZsQcK7eYusgIPsqZdaBCIJiW4imwUtnaAthWhRANCAAQT1nO46ipxVTilUH2umZPN7OPI49GU6Y8YkcqLxFKUgypUzGbYR2VJGM\\+QJXk0PI339EyYkt6tjgfS\\+RcOMQNO",
         "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEE9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIMqVMxm2EdlSRjPkCV5NDyN9/RMmJLerY4H0vkXDjEDTg==",
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\\.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ\\..*",
@@ -124,5 +129,5 @@
     }
   ],
   "results": {},
-  "generated_at": "2023-12-12T21:10:19Z"
+  "generated_at": "2024-08-01T10:25:51Z"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,10 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "3.0.2"
-		pact_provider_version	 : "4.5.11"
+		cri_common_lib           : "3.0.3",
+		pact_provider_version	 : "4.5.11",
+		webcompere_version       : "2.1.6",
+		slf4j_log4j12_version    : "2.0.13", // For contract test debug
 	]
 }
 
@@ -57,6 +59,7 @@ subprojects {
 		gson
 		powertools
 		mockito
+		webcompere
 		cri_common_lib
 		pact_tests
 	}
@@ -105,6 +108,9 @@ subprojects {
 				"org.hamcrest:hamcrest:2.2"
 
 		test_runtime "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
+
+		webcompere "uk.org.webcompere:system-stubs-core:${dependencyVersions.webcompere_version}",
+				"uk.org.webcompere:system-stubs-jupiter:${dependencyVersions.webcompere_version}"
 
 		pact_tests "au.com.dius.pact.provider:junit5:${dependencyVersions.pact_provider_version}",
 				"au.com.dius.pact:provider:${dependencyVersions.pact_provider_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ ext {
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
 		cri_common_lib           : "3.0.2"
+		pact_provider_version	 : "4.5.11"
 	]
 }
 
@@ -57,6 +58,7 @@ subprojects {
 		powertools
 		mockito
 		cri_common_lib
+		pact_tests
 	}
 
 	// The dynamodb enhanced package loads the apache-client as well as the spi-client, so
@@ -103,11 +105,20 @@ subprojects {
 				"org.hamcrest:hamcrest:2.2"
 
 		test_runtime "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
+
+		pact_tests "au.com.dius.pact.provider:junit5:${dependencyVersions.pact_provider_version}",
+				"au.com.dius.pact:provider:${dependencyVersions.pact_provider_version}"
 	}
 
 	test {
 		// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
 		environment "LAMBDA_TASK_ROOT", "handler"
+	}
+
+	tasks.register("pactTests", Test) {
+		useJUnitPlatform {
+			includeTags 'Pact'
+		}
 	}
 }
 

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -16,12 +16,15 @@ dependencies {
 
 	aspect configurations.powertools
 
-	testImplementation configurations.tests
+	testImplementation configurations.tests,
+			configurations.pact_tests
 	testRuntimeOnly configurations.test_runtime
 }
 
 test {
-	useJUnitPlatform()
+	useJUnitPlatform{
+		excludeTags 'Pact'
+	}
 	finalizedBy jacocoTestReport
 }
 

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -17,7 +17,10 @@ dependencies {
 	aspect configurations.powertools
 
 	testImplementation configurations.tests,
-			configurations.pact_tests
+			configurations.pact_tests,
+			configurations.webcompere,
+			"org.slf4j:slf4j-log4j12:2.0.13"
+
 	testRuntimeOnly configurations.test_runtime
 }
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/domain/VerifiableCredentialConstants.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/domain/VerifiableCredentialConstants.java
@@ -3,7 +3,7 @@ package uk.gov.di.ipv.cri.address.api.domain;
 public class VerifiableCredentialConstants {
     public static final String W3_BASE_CONTEXT = "https://www.w3.org/2018/credentials/v1";
     public static final String DI_CONTEXT =
-            "https://vocab.london.cloudapps.digital/contexts/identity-v1.jsonld";
+            "https://vocab.account.gov.uk/contexts/identity-v1.jsonld";
     public static final String ADDRESS_CREDENTIAL_TYPE = "AddressCredential";
     public static final String VC_ADDRESS_KEY = "address";
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -145,7 +146,11 @@ public class IssueCredentialHandler
                     OAuth2Error.SERVER_ERROR
                             .appendDescription(" - " + ex.awsErrorDetails().errorMessage())
                             .toJSONObject());
-        } catch (CredentialRequestException | ParseException | JOSEException e) {
+        } catch (CredentialRequestException
+                | ParseException
+                | JOSEException
+                | JsonProcessingException
+                | java.text.ParseException e) {
             eventProbe.log(ERROR, e).counterMetric(ADDRESS_CREDENTIAL_ISSUER, 0d);
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/objectmapper/CustomObjectMapper.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/objectmapper/CustomObjectMapper.java
@@ -1,0 +1,34 @@
+package uk.gov.di.ipv.cri.address.api.objectmapper;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.nimbusds.jwt.JWTClaimsSet;
+import uk.gov.di.ipv.cri.address.api.objectmapper.mixin.AddressMixIn;
+import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
+
+public class CustomObjectMapper {
+    private CustomObjectMapper() {
+        throw new UnsupportedOperationException("CustomObjectMapper - cannot be instantiated");
+    }
+
+    public static ObjectMapper getMapperWithCustomSerializers() {
+        ObjectMapper objectMapper =
+                new ObjectMapper()
+                        .registerModule(new Jdk8Module())
+                        .registerModule(new JavaTimeModule())
+                        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                        .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+
+        objectMapper.addMixIn(CanonicalAddress.class, AddressMixIn.class);
+
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(JWTClaimsSet.class, new JWTClaimsSetSerializer());
+        objectMapper.registerModule(module);
+
+        return objectMapper;
+    }
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/objectmapper/JWTClaimsSetSerializer.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/objectmapper/JWTClaimsSetSerializer.java
@@ -1,0 +1,78 @@
+package uk.gov.di.ipv.cri.address.api.objectmapper;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.nimbusds.jwt.JWTClaimsSet;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class JWTClaimsSetSerializer extends JsonSerializer<JWTClaimsSet> {
+
+    public static final String BIRTH_DATE = "birthDate";
+    public static final String NAME = "name";
+    public static final String ADDRESS = "address";
+
+    @Override
+    public void serialize(JWTClaimsSet claimsSet, JsonGenerator gen, SerializerProvider serializers)
+            throws IOException {
+        gen.writeStartObject();
+
+        if (claimsSet.getIssuer() != null) {
+            gen.writeStringField("iss", claimsSet.getIssuer());
+        }
+        if (claimsSet.getSubject() != null) {
+            gen.writeStringField("sub", claimsSet.getSubject());
+        }
+        if (claimsSet.getNotBeforeTime() != null) {
+            gen.writeNumberField("nbf", claimsSet.getNotBeforeTime().getTime() / 1000);
+        }
+        if (claimsSet.getExpirationTime() != null) {
+            gen.writeNumberField("exp", claimsSet.getExpirationTime().getTime() / 1000);
+        }
+
+        serializeVcClaim(claimsSet.getClaim("vc"), gen);
+
+        if (claimsSet.getJWTID() != null) {
+            gen.writeStringField("jti", claimsSet.getJWTID());
+        }
+
+        gen.writeEndObject();
+    }
+
+    private void serializeVcClaim(Object vcClaim, JsonGenerator gen) throws IOException {
+        if (vcClaim instanceof Map) {
+            Map<String, Object> vc = (Map<String, Object>) vcClaim;
+            gen.writeObjectFieldStart("vc");
+
+            for (Map.Entry<String, Object> entry : vc.entrySet()) {
+                if ("credentialSubject".equals(entry.getKey()) && entry.getValue() instanceof Map) {
+                    serializeCredentialSubject((Map<String, Object>) entry.getValue(), gen);
+                } else {
+                    gen.writeObjectField(entry.getKey(), entry.getValue());
+                }
+            }
+
+            gen.writeEndObject();
+        }
+    }
+
+    private void serializeCredentialSubject(
+            Map<String, Object> credentialSubject, JsonGenerator gen) throws IOException {
+        gen.writeObjectFieldStart("credentialSubject");
+
+        // Order the fields as name, birthDate, address
+        if (credentialSubject.containsKey(NAME)) {
+            gen.writeObjectField(NAME, credentialSubject.get(NAME));
+        }
+        if (credentialSubject.containsKey(BIRTH_DATE)) {
+            gen.writeObjectField(BIRTH_DATE, credentialSubject.get(BIRTH_DATE));
+        }
+        if (credentialSubject.containsKey(ADDRESS)) {
+            gen.writeObjectField(ADDRESS, credentialSubject.get(ADDRESS));
+        }
+
+        gen.writeEndObject();
+    }
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/objectmapper/mixin/AddressMixIn.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/objectmapper/mixin/AddressMixIn.java
@@ -1,0 +1,16 @@
+package uk.gov.di.ipv.cri.address.api.objectmapper.mixin;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+
+@JsonPropertyOrder({
+    "addressCountry",
+    "buildingName",
+    "streetName",
+    "postalCode",
+    "buildingNumber",
+    "addressLocality",
+    "validFrom"
+})
+@ExcludeFromGeneratedCoverageReport
+public abstract class AddressMixIn {}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/AddressInvalidVc403Test.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/AddressInvalidVc403Test.java
@@ -1,0 +1,107 @@
+package uk.gov.di.ipv.cri.address.api.handler.pact;
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget;
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.address.api.handler.IssueCredentialHandler;
+import uk.gov.di.ipv.cri.address.api.handler.pact.states.DummyStates;
+import uk.gov.di.ipv.cri.address.api.handler.pact.util.Injector;
+import uk.gov.di.ipv.cri.address.api.handler.pact.util.MockHttpServer;
+import uk.gov.di.ipv.cri.common.library.exception.SessionExpiredException;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.address.api.handler.IssueCredentialHandler.ADDRESS_CREDENTIAL_ISSUER;
+
+@Tag("Pact")
+@Provider("AddressCriVcProvider")
+@PactFolder("pacts")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
+class AddressInvalidVc403Test implements DummyStates {
+    @SystemStub private EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    private static final int PORT = 5010;
+    private static final boolean ENABLE_FULL_DEBUG = true;
+    @Mock private SessionService mockSessionService;
+    @Mock private EventProbe mockEventProbe;
+
+    @InjectMocks private IssueCredentialHandler handler;
+
+    @BeforeAll
+    void setup() {
+        System.setProperty("pact.filter.description", "Invalid credential request");
+        System.setProperty("pact.verifier.publishResults", "true");
+        System.setProperty("pact.content_type.override.application/jwt", "text");
+
+        if (ENABLE_FULL_DEBUG) {
+            // AutoConfig SL4j with Log4J
+            BasicConfigurator.configure();
+            Configurator.setAllLevels("", Level.DEBUG);
+        }
+    }
+
+    @AfterEach
+    public void tearDown() {
+        MockHttpServer.stopServer();
+    }
+
+    @BeforeEach
+    void pactSetup(PactVerificationContext context) throws IOException, ParseException {
+
+        environmentVariables.set("LAMBDA_TASK_ROOT", "handler");
+
+        AccessToken accessToken =
+                AccessToken.parse("Bearer dummyInvalidAccessToken", AccessTokenType.BEARER);
+        when(mockSessionService.getSessionByAccessToken(accessToken))
+                .thenThrow(new SessionExpiredException("session expired"));
+
+        MockHttpServer.startServer(
+                new ArrayList<>(List.of(new Injector(handler, "/credential/issue", "/"))), PORT);
+
+        context.setTarget(new HttpTestTarget("localhost", PORT));
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTest(PactVerificationContext context) {
+        context.verifyInteraction();
+    }
+
+    @State("dummyInvalidAccessToken is an invalid access token")
+    void validDummyAccessToken() {
+        when(mockEventProbe.log(eq(Level.ERROR), Mockito.any(Exception.class)))
+                .thenReturn(mockEventProbe);
+        when(mockEventProbe.counterMetric(ADDRESS_CREDENTIAL_ISSUER, 0d))
+                .thenReturn(mockEventProbe);
+    }
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/MultipleAddressVcTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/MultipleAddressVcTest.java
@@ -1,0 +1,183 @@
+package uk.gov.di.ipv.cri.address.api.handler.pact;
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget;
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.address.api.handler.IssueCredentialHandler;
+import uk.gov.di.ipv.cri.address.api.handler.pact.states.DummyStates;
+import uk.gov.di.ipv.cri.address.api.handler.pact.states.MultipleAddressStates;
+import uk.gov.di.ipv.cri.address.api.handler.pact.util.Injector;
+import uk.gov.di.ipv.cri.address.api.handler.pact.util.MockHttpServer;
+import uk.gov.di.ipv.cri.address.api.service.VerifiableCredentialService;
+import uk.gov.di.ipv.cri.address.library.persistence.item.AddressItem;
+import uk.gov.di.ipv.cri.address.library.service.AddressService;
+import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+import uk.gov.di.ipv.cri.common.library.service.AuditService;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.common.library.util.SignedJWTFactory;
+import uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.address.api.handler.pact.util.JwtSigner.getEcdsaSigner;
+import static uk.gov.di.ipv.cri.address.api.objectmapper.CustomObjectMapper.getMapperWithCustomSerializers;
+import static uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder.ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID;
+
+@Tag("Pact")
+@Provider("AddressCriVcProvider")
+@PactFolder("pacts")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
+class MultipleAddressVcTest implements DummyStates, MultipleAddressStates {
+    @SystemStub private EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    private static final int PORT = 5010;
+    private static final boolean ENABLE_FULL_DEBUG = true;
+    public static final String SUBJECT = "test-subject";
+    private final UUID sessionId = UUID.randomUUID();
+    @Mock private SessionService mockSessionService;
+    @Mock private AddressService mockAddressService;
+    @Mock private EventProbe mockEventProbe;
+    @Mock private AuditService mockAuditService;
+    @Mock private ConfigurationService mockConfigurationService;
+    @InjectMocks private IssueCredentialHandler handler;
+    private VerifiableCredentialService verifiableCredentialService;
+
+    @BeforeAll
+    void setup() {
+        System.setProperty(
+                "pact.filter.description", "Valid credential request for multiple addresses");
+        System.setProperty("pact.verifier.publishResults", "true");
+        System.setProperty("pact.content_type.override.application/jwt", "text");
+
+        if (ENABLE_FULL_DEBUG) {
+            // AutoConfig SL4j with Log4J
+            BasicConfigurator.configure();
+            Configurator.setAllLevels("", Level.DEBUG);
+        }
+    }
+
+    @AfterEach
+    public void tearDown() {
+        MockHttpServer.stopServer();
+    }
+
+    @BeforeEach
+    void pactSetup(PactVerificationContext context)
+            throws IOException, JOSEException, NoSuchAlgorithmException, InvalidKeySpecException {
+
+        environmentVariables.set("LAMBDA_TASK_ROOT", "handler");
+        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID, "override");
+
+        SignedJWTFactory signedJwtFactory = new SignedJWTFactory(getEcdsaSigner());
+        ObjectMapper objectMapper = getMapperWithCustomSerializers();
+
+        Clock clock = Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneId.of("UTC"));
+        VerifiableCredentialClaimsSetBuilder claimsSetBuilder =
+                new VerifiableCredentialClaimsSetBuilder(mockConfigurationService, clock);
+        claimsSetBuilder.overrideJti("dummyJti");
+
+        verifiableCredentialService =
+                new VerifiableCredentialService(
+                        signedJwtFactory, mockConfigurationService, objectMapper, claimsSetBuilder);
+
+        handler =
+                new IssueCredentialHandler(
+                        verifiableCredentialService,
+                        mockAddressService,
+                        mockSessionService,
+                        mockEventProbe,
+                        mockAuditService);
+
+        MockHttpServer.startServer(
+                new ArrayList<>(List.of(new Injector(handler, "/credential/issue", "/"))), PORT);
+
+        context.setTarget(new HttpTestTarget("localhost", PORT));
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTest(PactVerificationContext context) {
+        context.verifyInteraction();
+    }
+
+    @State("dummyAccessToken is a valid access token")
+    void validDummyAccessToken() throws ParseException {
+        AccessToken accessToken =
+                AccessToken.parse("Bearer dummyAccessToken", AccessTokenType.BEARER);
+        when(mockSessionService.getSessionByAccessToken(accessToken)).thenReturn(getSessionItem());
+        AddressItem addressItem = new AddressItem();
+        addressItem.setAddresses(getCanonicalAddresses());
+        when(mockAddressService.getAddressItem(sessionId)).thenReturn(addressItem);
+        when(mockConfigurationService.getVerifiableCredentialIssuer())
+                .thenReturn("dummyAddressComponentId");
+        when(mockConfigurationService.getMaxJwtTtl()).thenReturn(10L);
+        when(mockConfigurationService.getParameterValue("JwtTtlUnit")).thenReturn("MINUTES");
+    }
+
+    @NotNull
+    private SessionItem getSessionItem() {
+        SessionItem sessionItem = new SessionItem();
+        sessionItem.setSubject(SUBJECT);
+        sessionItem.setSessionId(sessionId);
+        sessionItem.setAccessToken("Bearer dummyAccessToken");
+        return sessionItem;
+    }
+
+    @NotNull
+    private List<CanonicalAddress> getCanonicalAddresses() {
+        CanonicalAddress firstAddress = new CanonicalAddress();
+        firstAddress.setBuildingName("221B");
+        firstAddress.setStreetName("BAKER STREET");
+        firstAddress.setPostalCode("NW1 6XE");
+        firstAddress.setAddressLocality("LONDON");
+        firstAddress.setValidFrom(LocalDate.of(1987, 1, 1));
+
+        CanonicalAddress secondAddress = new CanonicalAddress();
+        secondAddress.setBuildingName("122");
+        secondAddress.setStreetName("BURNS CRESCENT");
+        secondAddress.setPostalCode("EH1 9GP");
+        secondAddress.setAddressLocality("EDINBURGH");
+        secondAddress.setValidFrom(LocalDate.of(2017, 1, 1));
+
+        return List.of(firstAddress, secondAddress);
+    }
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/SingleAddressBuildNumberVcTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/SingleAddressBuildNumberVcTest.java
@@ -1,0 +1,178 @@
+package uk.gov.di.ipv.cri.address.api.handler.pact;
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget;
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.address.api.handler.IssueCredentialHandler;
+import uk.gov.di.ipv.cri.address.api.handler.pact.states.DummyStates;
+import uk.gov.di.ipv.cri.address.api.handler.pact.states.SingleAddressBuildingNumberStates;
+import uk.gov.di.ipv.cri.address.api.handler.pact.util.Injector;
+import uk.gov.di.ipv.cri.address.api.handler.pact.util.MockHttpServer;
+import uk.gov.di.ipv.cri.address.api.service.VerifiableCredentialService;
+import uk.gov.di.ipv.cri.address.library.persistence.item.AddressItem;
+import uk.gov.di.ipv.cri.address.library.service.AddressService;
+import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+import uk.gov.di.ipv.cri.common.library.service.AuditService;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.common.library.util.SignedJWTFactory;
+import uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.address.api.handler.pact.util.JwtSigner.getEcdsaSigner;
+import static uk.gov.di.ipv.cri.address.api.objectmapper.CustomObjectMapper.getMapperWithCustomSerializers;
+import static uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder.ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID;
+
+@Tag("Pact")
+@Provider("AddressCriVcProvider")
+@PactFolder("pacts")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
+class SingleAddressBuildNumberVcTest implements DummyStates, SingleAddressBuildingNumberStates {
+    @SystemStub private EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    private static final int PORT = 5010;
+    private static final boolean ENABLE_FULL_DEBUG = true;
+    public static final String SUBJECT = "test-subject";
+    private final UUID sessionId = UUID.randomUUID();
+    @Mock private SessionService mockSessionService;
+    @Mock private AddressService mockAddressService;
+    @Mock private EventProbe mockEventProbe;
+    @Mock private AuditService mockAuditService;
+    @Mock private ConfigurationService mockConfigurationService;
+    @InjectMocks private IssueCredentialHandler handler;
+    private VerifiableCredentialService verifiableCredentialService;
+
+    @BeforeAll
+    void setup() {
+        System.setProperty("pact.filter.description", "Valid credential request for Experian VC");
+        System.setProperty("pact.verifier.publishResults", "true");
+        System.setProperty("pact.content_type.override.application/jwt", "text");
+
+        if (ENABLE_FULL_DEBUG) {
+            // AutoConfig SL4j with Log4J
+            BasicConfigurator.configure();
+            Configurator.setAllLevels("", Level.DEBUG);
+        }
+    }
+
+    @AfterEach
+    public void tearDown() {
+        MockHttpServer.stopServer();
+    }
+
+    @BeforeEach
+    void pactSetup(PactVerificationContext context)
+            throws IOException, JOSEException, NoSuchAlgorithmException, InvalidKeySpecException {
+
+        environmentVariables.set("LAMBDA_TASK_ROOT", "handler");
+        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID, "override");
+
+        SignedJWTFactory signedJwtFactory = new SignedJWTFactory(getEcdsaSigner());
+        ObjectMapper objectMapper = getMapperWithCustomSerializers();
+
+        Clock clock = Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneId.of("UTC"));
+        VerifiableCredentialClaimsSetBuilder claimsSetBuilder =
+                new VerifiableCredentialClaimsSetBuilder(mockConfigurationService, clock);
+        claimsSetBuilder.overrideJti("dummyJti");
+
+        verifiableCredentialService =
+                new VerifiableCredentialService(
+                        signedJwtFactory, mockConfigurationService, objectMapper, claimsSetBuilder);
+        handler =
+                new IssueCredentialHandler(
+                        verifiableCredentialService,
+                        mockAddressService,
+                        mockSessionService,
+                        mockEventProbe,
+                        mockAuditService);
+
+        MockHttpServer.startServer(
+                new ArrayList<>(List.of(new Injector(handler, "/credential/issue", "/"))), PORT);
+
+        context.setTarget(new HttpTestTarget("localhost", PORT));
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTest(PactVerificationContext context) {
+        context.verifyInteraction();
+    }
+
+    @State("dummyAccessToken is a valid access token")
+    void validDummyAccessToken() throws ParseException {
+        AccessToken accessToken =
+                AccessToken.parse("Bearer dummyAccessToken", AccessTokenType.BEARER);
+        when(mockSessionService.getSessionByAccessToken(accessToken)).thenReturn(getSessionItem());
+        AddressItem addressItem = new AddressItem();
+        addressItem.setAddresses(getCanonicalAddresses());
+        when(mockAddressService.getAddressItem(sessionId)).thenReturn(addressItem);
+        when(mockConfigurationService.getVerifiableCredentialIssuer())
+                .thenReturn("dummyAddressComponentId");
+        when(mockConfigurationService.getMaxJwtTtl()).thenReturn(10L);
+        when(mockConfigurationService.getParameterValue("JwtTtlUnit")).thenReturn("MINUTES");
+    }
+
+    @NotNull
+    private SessionItem getSessionItem() {
+        SessionItem sessionItem = new SessionItem();
+        sessionItem.setSubject(SUBJECT);
+        sessionItem.setSessionId(sessionId);
+        sessionItem.setAccessToken("Bearer dummyAccessToken");
+        return sessionItem;
+    }
+
+    @NotNull
+    private List<CanonicalAddress> getCanonicalAddresses() {
+        CanonicalAddress address = new CanonicalAddress();
+        address.setAddressCountry("GB");
+        address.setBuildingName("");
+        address.setStreetName("HADLEY ROAD");
+        address.setPostalCode("BA2 5AA");
+        address.setBuildingNumber("8");
+        address.setAddressLocality("BATH");
+        address.setPostalCode("BA2 5AA");
+        address.setValidFrom(LocalDate.of(2000, 1, 1));
+
+        return Collections.singletonList(address);
+    }
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/SingleAddressBuildingNameVcTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/SingleAddressBuildingNameVcTest.java
@@ -1,0 +1,176 @@
+package uk.gov.di.ipv.cri.address.api.handler.pact;
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget;
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.address.api.handler.IssueCredentialHandler;
+import uk.gov.di.ipv.cri.address.api.handler.pact.states.DummyStates;
+import uk.gov.di.ipv.cri.address.api.handler.pact.states.SingleAddressBuildingNameStates;
+import uk.gov.di.ipv.cri.address.api.handler.pact.util.Injector;
+import uk.gov.di.ipv.cri.address.api.handler.pact.util.MockHttpServer;
+import uk.gov.di.ipv.cri.address.api.service.VerifiableCredentialService;
+import uk.gov.di.ipv.cri.address.library.persistence.item.AddressItem;
+import uk.gov.di.ipv.cri.address.library.service.AddressService;
+import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
+import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+import uk.gov.di.ipv.cri.common.library.service.AuditService;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.service.SessionService;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
+import uk.gov.di.ipv.cri.common.library.util.SignedJWTFactory;
+import uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.address.api.handler.pact.util.JwtSigner.getEcdsaSigner;
+import static uk.gov.di.ipv.cri.address.api.objectmapper.CustomObjectMapper.getMapperWithCustomSerializers;
+import static uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder.ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID;
+
+@Tag("Pact")
+@Provider("AddressCriVcProvider")
+@PactFolder("pacts")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
+class SingleAddressBuildingNameVcTest implements DummyStates, SingleAddressBuildingNameStates {
+    @SystemStub private EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    private static final int PORT = 5010;
+    private static final boolean ENABLE_FULL_DEBUG = true;
+    public static final String SUBJECT = "test-subject";
+    private final UUID sessionId = UUID.randomUUID();
+    @Mock private SessionService mockSessionService;
+    @Mock private AddressService mockAddressService;
+    @Mock private EventProbe mockEventProbe;
+    @Mock private AuditService mockAuditService;
+    @Mock private ConfigurationService mockConfigurationService;
+    @InjectMocks private IssueCredentialHandler handler;
+    private VerifiableCredentialService verifiableCredentialService;
+
+    @BeforeAll
+    void setup() {
+        System.setProperty(
+                "pact.filter.description", "Valid credential request for old single address");
+        System.setProperty("pact.verifier.publishResults", "true");
+        System.setProperty("pact.content_type.override.application/jwt", "text");
+
+        if (ENABLE_FULL_DEBUG) {
+            // AutoConfig SL4j with Log4J
+            BasicConfigurator.configure();
+            Configurator.setAllLevels("", Level.DEBUG);
+        }
+    }
+
+    @AfterEach
+    public void tearDown() {
+        MockHttpServer.stopServer();
+    }
+
+    @BeforeEach
+    void pactSetup(PactVerificationContext context)
+            throws IOException, JOSEException, NoSuchAlgorithmException, InvalidKeySpecException {
+
+        environmentVariables.set("LAMBDA_TASK_ROOT", "handler");
+        environmentVariables.set(ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID, "override");
+
+        SignedJWTFactory signedJwtFactory = new SignedJWTFactory(getEcdsaSigner());
+        ObjectMapper objectMapper = getMapperWithCustomSerializers();
+
+        Clock clock = Clock.fixed(Instant.parse("2099-01-01T00:00:00.00Z"), ZoneId.of("UTC"));
+        VerifiableCredentialClaimsSetBuilder claimsSetBuilder =
+                new VerifiableCredentialClaimsSetBuilder(mockConfigurationService, clock);
+        claimsSetBuilder.overrideJti("dummyJti");
+
+        verifiableCredentialService =
+                new VerifiableCredentialService(
+                        signedJwtFactory, mockConfigurationService, objectMapper, claimsSetBuilder);
+        handler =
+                new IssueCredentialHandler(
+                        verifiableCredentialService,
+                        mockAddressService,
+                        mockSessionService,
+                        mockEventProbe,
+                        mockAuditService);
+
+        MockHttpServer.startServer(
+                new ArrayList<>(List.of(new Injector(handler, "/credential/issue", "/"))), PORT);
+
+        context.setTarget(new HttpTestTarget("localhost", PORT));
+    }
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTest(PactVerificationContext context) {
+        context.verifyInteraction();
+    }
+
+    @State("dummyAccessToken is a valid access token")
+    void validDummyAccessToken() throws ParseException {
+        AccessToken accessToken =
+                AccessToken.parse("Bearer dummyAccessToken", AccessTokenType.BEARER);
+        when(mockSessionService.getSessionByAccessToken(accessToken)).thenReturn(getSessionItem());
+        AddressItem addressItem = new AddressItem();
+        addressItem.setAddresses(getCanonicalAddresses());
+        when(mockAddressService.getAddressItem(sessionId)).thenReturn(addressItem);
+        when(mockConfigurationService.getVerifiableCredentialIssuer())
+                .thenReturn("dummyAddressComponentId");
+        when(mockConfigurationService.getMaxJwtTtl()).thenReturn(10L);
+        when(mockConfigurationService.getParameterValue("JwtTtlUnit")).thenReturn("MINUTES");
+    }
+
+    @NotNull
+    private SessionItem getSessionItem() {
+        SessionItem sessionItem = new SessionItem();
+        sessionItem.setSubject(SUBJECT);
+        sessionItem.setSessionId(sessionId);
+        sessionItem.setAccessToken("Bearer dummyAccessToken");
+        return sessionItem;
+    }
+
+    @NotNull
+    private List<CanonicalAddress> getCanonicalAddresses() {
+        CanonicalAddress firstAddress = new CanonicalAddress();
+        firstAddress.setBuildingName("221B");
+        firstAddress.setStreetName("BAKER STREET");
+        firstAddress.setPostalCode("NW1 6XE");
+        firstAddress.setAddressLocality("LONDON");
+        firstAddress.setValidFrom(LocalDate.of(1887, 1, 1));
+
+        return Collections.singletonList(firstAddress);
+    }
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/states/DummyStates.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/states/DummyStates.java
@@ -1,0 +1,14 @@
+package uk.gov.di.ipv.cri.address.api.handler.pact.states;
+
+import au.com.dius.pact.provider.junitsupport.State;
+
+public interface DummyStates {
+    @State("dummyApiKey is a valid api key")
+    default void validDummyApiKey() {}
+
+    @State("dummyAddressComponentId is a valid issuer")
+    default void validDummyAddressComponent() {}
+
+    @State("test-subject is a valid subject")
+    default void validSubject() {}
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/states/MultipleAddressStates.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/states/MultipleAddressStates.java
@@ -1,0 +1,41 @@
+package uk.gov.di.ipv.cri.address.api.handler.pact.states;
+
+import au.com.dius.pact.provider.junitsupport.State;
+
+public interface MultipleAddressStates {
+    @State("Valid credential request for VC")
+    default void validCredentialGenerated() {}
+
+    @State("Invalid credential request")
+    default void inValidCredentialGenerated() {}
+
+    @State("buildingName is 221B")
+    default void buildingName() {}
+
+    @State("streetName is BAKER STREET")
+    default void validStreetName() {}
+
+    @State("postalCode is NW1 6XE")
+    default void postCode() {}
+
+    @State("addressLocality is LONDON")
+    default void validAddressLocality() {}
+
+    @State("validFrom is 1987-01-01")
+    default void validFromDate() {}
+
+    @State("second buildingName is 122")
+    default void secondBuildingName() {}
+
+    @State("second streetName is BURNS CRESCENT")
+    default void secondValidStreetName() {}
+
+    @State("second postalCode is EH1 9GP")
+    default void secondPostCode() {}
+
+    @State("second addressLocality is EDINBURGH")
+    default void secondValidAddressLocality() {}
+
+    @State("second validFrom is 2017-01-01")
+    default void secondValidFromDate() {}
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/states/SingleAddressBuildingNameStates.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/states/SingleAddressBuildingNameStates.java
@@ -1,0 +1,26 @@
+package uk.gov.di.ipv.cri.address.api.handler.pact.states;
+
+import au.com.dius.pact.provider.junitsupport.State;
+
+public interface SingleAddressBuildingNameStates {
+    @State("Valid credential request for VC")
+    default void validCredentialGenerated() {}
+
+    @State("Invalid credential request")
+    default void inValidCredentialGenerated() {}
+
+    @State("buildingName is 221B")
+    default void buildingName() {}
+
+    @State("streetName is BAKER STREET")
+    default void validStreetName() {}
+
+    @State("postalCode is NW1 6XE")
+    default void postCode() {}
+
+    @State("addressLocality is LONDON")
+    default void validAddressLocality() {}
+
+    @State("validFrom is 1887-01-01")
+    default void validFromDate() {}
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/states/SingleAddressBuildingNumberStates.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/states/SingleAddressBuildingNumberStates.java
@@ -1,0 +1,26 @@
+package uk.gov.di.ipv.cri.address.api.handler.pact.states;
+
+import au.com.dius.pact.provider.junitsupport.State;
+
+public interface SingleAddressBuildingNumberStates {
+    @State("Valid credential request for Experian VC")
+    default void validCredentialGenerated() {}
+
+    @State("Invalid credential request")
+    default void inValidCredentialGenerated() {}
+
+    @State("addressCountry is GB")
+    default void validAddressCountry() {}
+
+    @State("streetName is HADLEY ROAD")
+    default void validStreetName() {}
+
+    @State("buildingNumber is 8")
+    default void validBuildingNumber() {}
+
+    @State("addressLocality is BATH")
+    default void validAddressLocality() {}
+
+    @State("validFrom is 2000-01-01")
+    default void validFromDate() {}
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/util/Injector.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/util/Injector.java
@@ -1,0 +1,55 @@
+package uk.gov.di.ipv.cri.address.api.handler.pact.util;
+
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Injector {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private final RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> handler;
+    private final String endpoint;
+
+    private final String pathDescription;
+
+    private final Map<Integer, String> pathParams;
+
+    public Injector(
+            RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> handler,
+            String endpoint,
+            String pathDescription) {
+        this.endpoint = endpoint;
+        this.handler = handler;
+        this.pathDescription = pathDescription;
+        this.pathParams = new HashMap<>();
+        this.findPathParams();
+    }
+
+    public RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> getHandler() {
+        return handler;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public Map<Integer, String> getPathParams() {
+        return this.pathParams;
+    }
+
+    private void findPathParams() {
+        String[] arr = pathDescription.split("/");
+        for (int i = 0; i < arr.length; i++) {
+            if (arr[i].charAt(0) == '{') {
+                pathParams.put(i, arr[i].substring(1, arr.length));
+                LOGGER.info("added path param : {} with key: {}", pathParams.get(i), i);
+            }
+        }
+    }
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/util/JwtSigner.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/util/JwtSigner.java
@@ -1,0 +1,33 @@
+package uk.gov.di.ipv.cri.address.api.handler.pact.util;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import org.jetbrains.annotations.NotNull;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+
+import static uk.gov.di.ipv.cri.address.api.service.fixtures.TestFixtures.EC_PRIVATE_KEY_1;
+
+public class JwtSigner {
+    private JwtSigner() {
+        throw new UnsupportedOperationException("JwtSigner - cannot be instantiated");
+    }
+
+    @NotNull
+    public static ECDSASigner getEcdsaSigner()
+            throws InvalidKeySpecException, NoSuchAlgorithmException, JOSEException {
+        ECPrivateKey privateKey =
+                (ECPrivateKey)
+                        KeyFactory.getInstance("EC")
+                                .generatePrivate(
+                                        new PKCS8EncodedKeySpec(
+                                                Base64.getDecoder().decode(EC_PRIVATE_KEY_1)));
+
+        return new ECDSASigner(privateKey);
+    }
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/util/MockHttpServer.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/util/MockHttpServer.java
@@ -1,0 +1,28 @@
+package uk.gov.di.ipv.cri.address.api.handler.pact.util;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.concurrent.Executors;
+
+public class MockHttpServer {
+
+    private static HttpServer server;
+
+    public static void startServer(ArrayList<Injector> endpointList, int port) throws IOException {
+
+        server = HttpServer.create(new InetSocketAddress(port), 0);
+        endpointList.forEach(
+                injector ->
+                        server.createContext(
+                                injector.getEndpoint(), new PreLambdaHandler(injector)));
+        server.setExecutor(Executors.newCachedThreadPool()); // creates a default executor
+        server.start();
+    }
+
+    public static void stopServer() {
+        server.stop(0);
+    }
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/util/PreLambdaHandler.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/util/PreLambdaHandler.java
@@ -1,0 +1,148 @@
+package uk.gov.di.ipv.cri.address.api.handler.pact.util;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.mock;
+
+public class PreLambdaHandler implements HttpHandler {
+    private static final Logger LOGGER = LogManager.getLogger();
+    private final RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> handler;
+    private final Map<Integer, String> pathParamsFromInjector;
+
+    public PreLambdaHandler(Injector injector) {
+        this.handler = injector.getHandler();
+        this.pathParamsFromInjector = injector.getPathParams();
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+
+        try {
+            APIGatewayProxyRequestEvent request = translateRequest(exchange);
+            APIGatewayProxyResponseEvent response =
+                    this.handler.handleRequest(request, mock(Context.class));
+
+            LOGGER.info("Response has been returned lambda handler");
+            LOGGER.info(response.getBody());
+
+            translateResponse(response, exchange);
+
+        } catch (Exception e) {
+            LOGGER.error("Error caught in handler and thrown up to server");
+            LOGGER.error(e.getMessage(), e);
+            String err = "Some error occurred";
+            exchange.sendResponseHeaders(500, err.length());
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(err.getBytes());
+            }
+        }
+    }
+
+    private Map<String, String> getHeaderMap(Headers h) {
+        return h.keySet().stream()
+                .collect(
+                        Collectors.toMap(
+                                key -> key,
+                                key -> String.join(", ", h.get(key)),
+                                (existing, replacement) -> existing));
+    }
+
+    private Map<String, String> getPathParameters(String requestURL) {
+        HashMap<String, String> pathParams = new HashMap<>();
+        String[] pathArr = requestURL.split("/");
+        if (!pathParamsFromInjector.isEmpty() && pathArr.length > 1) {
+            pathParamsFromInjector
+                    .keySet()
+                    .forEach(key -> pathParams.put(pathParamsFromInjector.get(key), pathArr[key]));
+        }
+        return pathParams;
+    }
+
+    public static Map<String, String> getQueryStringParams(URI url)
+            throws UnsupportedEncodingException {
+        Map<String, String> queryPairs = new HashMap<>();
+        String query = url.getQuery();
+        String[] pairs = query.split("&");
+        for (String pair : pairs) {
+            int idx = pair.indexOf("=");
+            queryPairs.put(
+                    URLDecoder.decode(pair.substring(0, idx), "UTF-8"),
+                    URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
+        }
+        return queryPairs;
+    }
+
+    private APIGatewayProxyRequestEvent translateRequest(HttpExchange request) throws IOException {
+
+        String requestBody = IOUtils.toString(request.getRequestBody(), StandardCharsets.UTF_8);
+        LOGGER.info("BODY FROM ORIGINAL REQUEST");
+        LOGGER.info(requestBody);
+
+        String requestPath = request.getRequestURI().getPath();
+
+        LOGGER.info(requestPath);
+
+        Headers requestHeaders = request.getRequestHeaders();
+
+        String requestId = UUID.randomUUID().toString();
+
+        APIGatewayProxyRequestEvent apiGatewayProxyRequestEvent =
+                new APIGatewayProxyRequestEvent()
+                        .withBody(requestBody)
+                        .withHeaders(getHeaderMap(requestHeaders))
+                        .withHttpMethod(request.getRequestMethod())
+                        .withPathParameters(getPathParameters(requestPath))
+                        .withRequestContext(
+                                new APIGatewayProxyRequestEvent.ProxyRequestContext()
+                                        .withRequestId(requestId));
+        String requestQuery = request.getRequestURI().getQuery();
+        LOGGER.info("query retrieved: {}", requestQuery);
+
+        if (requestQuery != null) {
+            apiGatewayProxyRequestEvent.setQueryStringParameters(
+                    getQueryStringParams(request.getRequestURI()));
+        }
+
+        LOGGER.info("BODY FROM AG FORMED REQUEST");
+        LOGGER.info(apiGatewayProxyRequestEvent.getBody());
+
+        return apiGatewayProxyRequestEvent;
+    }
+
+    private void translateResponse(APIGatewayProxyResponseEvent response, HttpExchange exchange)
+            throws IOException {
+
+        Integer statusCode = response.getStatusCode();
+        Headers serverResponseHeaders = exchange.getResponseHeaders();
+        response.getHeaders().forEach(serverResponseHeaders::set);
+        if (!response.getBody().isEmpty()) {
+            LOGGER.info("getting response body");
+
+            String body = response.getBody();
+            exchange.sendResponseHeaders(statusCode, response.getBody().length());
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body.getBytes());
+            }
+        }
+    }
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/objectmapper/CustomObjectMapperTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/objectmapper/CustomObjectMapperTest.java
@@ -1,0 +1,82 @@
+package uk.gov.di.ipv.cri.address.api.objectmapper;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class CustomObjectMapperTest {
+
+    @Test
+    void shouldConfigureObjectMapperCorrectly() {
+        ObjectMapper objectMapper = CustomObjectMapper.getMapperWithCustomSerializers();
+
+        assertEquals(
+                JsonInclude.Include.NON_NULL,
+                objectMapper
+                        .getSerializationConfig()
+                        .getDefaultPropertyInclusion()
+                        .getValueInclusion());
+        assertEquals(3, objectMapper.getRegisteredModuleIds().size());
+        assertFalse(
+                objectMapper
+                        .getSerializationConfig()
+                        .isEnabled(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS));
+    }
+
+    @Test
+    void shouldSerializeJWTClaimsSetCorrectly() throws IOException {
+        ObjectMapper objectMapper = CustomObjectMapper.getMapperWithCustomSerializers();
+
+        JWTClaimsSet claimsSet =
+                new JWTClaimsSet.Builder()
+                        .subject("subject")
+                        .issuer("issuer")
+                        .expirationTime(new Date(4070909400000L))
+                        .build();
+
+        String expectedJson = "{\"iss\":\"issuer\",\"sub\":\"subject\",\"exp\":4070909400}";
+
+        String actualJson = objectMapper.writeValueAsString(claimsSet);
+
+        assertEquals(expectedJson, actualJson);
+    }
+
+    @Test
+    void shouldSerializeWithCredentialSubject() throws IOException {
+        ObjectMapper objectMapper = CustomObjectMapper.getMapperWithCustomSerializers();
+
+        CanonicalAddress address = new CanonicalAddress();
+        address.setAddressCountry("GB");
+        address.setBuildingName("");
+        address.setStreetName("HADLEY ROAD");
+        address.setPostalCode("BA2 5AA");
+        address.setBuildingNumber("8");
+        address.setAddressLocality("BATH");
+        address.setPostalCode("BA2 5AA");
+
+        address.setValidFrom(LocalDate.of(2000, 1, 1));
+        Map<String, Object> vc = new HashMap<>();
+        vc.put("credentialSubject", Map.of("address", List.of(address)));
+
+        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder().claim("vc", vc).build();
+
+        String actualJson = objectMapper.writeValueAsString(claimsSet);
+
+        assertEquals(
+                "{\"vc\":{\"credentialSubject\":{\"address\":[{\"addressCountry\":\"GB\",\"buildingName\":\"\",\"streetName\":\"HADLEY ROAD\",\"postalCode\":\"BA2 5AA\",\"buildingNumber\":\"8\",\"addressLocality\":\"BATH\",\"validFrom\":\"2000-01-01\"}]}}}",
+                actualJson);
+    }
+}

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/objectmapper/JWTClaimsSetSerializerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/objectmapper/JWTClaimsSetSerializerTest.java
@@ -1,0 +1,65 @@
+package uk.gov.di.ipv.cri.address.api.objectmapper;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class JWTClaimsSetSerializerTest {
+    private JWTClaimsSetSerializer serializer;
+    private SerializerProvider serializerProvider;
+
+    @BeforeEach
+    void setUp() {
+        serializer = new JWTClaimsSetSerializer();
+        serializerProvider = mock(SerializerProvider.class);
+    }
+
+    @Test
+    void shouldOrderClaimsAsExpectedWhenSerialized() throws IOException {
+        JWTClaimsSet claimsSet =
+                new JWTClaimsSet.Builder()
+                        .notBeforeTime(new Date(4070908800000L))
+                        .subject("subject")
+                        .expirationTime(new Date(4070909400000L))
+                        .jwtID("dummyJti")
+                        .issuer("dummyAddressComponentId")
+                        .claim("vc", Collections.emptyMap())
+                        .build();
+
+        StringWriter writer = new StringWriter();
+        JsonGenerator generator = new ObjectMapper().getFactory().createGenerator(writer);
+
+        serializer.serialize(claimsSet, generator, serializerProvider);
+        generator.flush();
+
+        String expectedJson =
+                "{\"iss\":\"dummyAddressComponentId\",\"sub\":\"subject\",\"nbf\":4070908800,\"exp\":4070909400,\"vc\":{},\"jti\":\"dummyJti\"}";
+
+        assertEquals(expectedJson, writer.toString().trim());
+    }
+
+    @Test
+    void shouldSerializeEmptyClaimsSet() throws IOException {
+        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder().build();
+
+        StringWriter writer = new StringWriter();
+        JsonGenerator generator = new ObjectMapper().getFactory().createGenerator(writer);
+
+        serializer.serialize(claimsSet, generator, serializerProvider);
+        generator.flush();
+
+        String expectedJson = "{}";
+        assertEquals(expectedJson, writer.toString());
+    }
+}

--- a/lambdas/issuecredential/src/test/resources/pacts/addressCriVcPact.json
+++ b/lambdas/issuecredential/src/test/resources/pacts/addressCriVcPact.json
@@ -1,0 +1,240 @@
+{
+  "consumer": {
+    "name": "IpvCoreBack"
+  },
+  "interactions": [
+    {
+      "_id": "bb211618a79234dfc8207510d508e9f2442a94fb",
+      "description": "Valid credential request for Experian VC",
+      "providerStates": [
+        {
+          "name": "dummyApiKey is a valid api key"
+        },
+        {
+          "name": "dummyAccessToken is a valid access token"
+        },
+        {
+          "name": "test-subject is a valid subject"
+        },
+        {
+          "name": "dummyAddressComponentId is a valid issuer"
+        },
+        {
+          "name": "addressCountry is GB"
+        },
+        {
+          "name": "streetName is HADLEY ROAD"
+        },
+        {
+          "name": "buildingNumber is 8"
+        },
+        {
+          "name": "addressLocality is BATH"
+        },
+        {
+          "name": "validFrom is 2000-01-01"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer dummyAccessToken",
+          "x-api-key": "dummyApiKey"
+        },
+        "method": "POST",
+        "path": "/credential/issue"
+      },
+      "response": {
+        "body": "ZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKRlV6STFOaUo5LmV5SnBjM01pT2lKa2RXMXRlVUZrWkhKbGMzTkRiMjF3YjI1bGJuUkpaQ0lzSW5OMVlpSTZJblJsYzNRdGMzVmlhbVZqZENJc0ltNWlaaUk2TkRBM01Ea3dPRGd3TUN3aVpYaHdJam8wTURjd09UQTVOREF3TENKMll5STZleUowZVhCbElqcGJJbFpsY21sbWFXRmliR1ZEY21Wa1pXNTBhV0ZzSWl3aVFXUmtjbVZ6YzBOeVpXUmxiblJwWVd3aVhTd2lRR052Ym5SbGVIUWlPbHNpYUhSMGNITTZMeTkzZDNjdWR6TXViM0puTHpJd01UZ3ZZM0psWkdWdWRHbGhiSE12ZGpFaUxDSm9kSFJ3Y3pvdkwzWnZZMkZpTG1GalkyOTFiblF1WjI5MkxuVnJMMk52Ym5SbGVIUnpMMmxrWlc1MGFYUjVMWFl4TG1wemIyNXNaQ0pkTENKamNtVmtaVzUwYVdGc1UzVmlhbVZqZENJNmV5SmhaR1J5WlhOeklqcGJleUpoWkdSeVpYTnpRMjkxYm5SeWVTSTZJa2RDSWl3aVluVnBiR1JwYm1kT1lXMWxJam9pSWl3aWMzUnlaV1YwVG1GdFpTSTZJa2hCUkV4RldTQlNUMEZFSWl3aWNHOXpkR0ZzUTI5a1pTSTZJa0pCTWlBMVFVRWlMQ0ppZFdsc1pHbHVaMDUxYldKbGNpSTZJamdpTENKaFpHUnlaWE56VEc5allXeHBkSGtpT2lKQ1FWUklJaXdpZG1Gc2FXUkdjbTl0SWpvaU1qQXdNQzB3TVMwd01TSjlYWDE5TENKcWRHa2lPaUprZFcxdGVVcDBhU0o5LlVNR2tIaG1rZU5DN0hzSjVoOUJwTUFNQnNrMGpyVXZrU0R6UThYbTdmcmxFcHNaSHZJTFNqbUFVclNDV2F1R1ZlNTIteUc4eWJJT3JGYVhaYjhhVjhR",
+        "headers": {
+          "Content-Type": "application/jwt"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9\\.eyJpc3MiOiJkdW1teUFkZHJlc3NDb21wb25lbnRJZCIsInN1YiI6InRlc3Qtc3ViamVjdCIsIm5iZiI6NDA3MDkwODgwMCwiZXhwIjo0MDcwOTA5NDAwLCJ2YyI6eyJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiQWRkcmVzc0NyZWRlbnRpYWwiXSwiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3ZvY2FiLmFjY291bnQuZ292LnVrL2NvbnRleHRzL2lkZW50aXR5LXYxLmpzb25sZCJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJhZGRyZXNzIjpbeyJhZGRyZXNzQ291bnRyeSI6IkdCIiwiYnVpbGRpbmdOYW1lIjoiIiwic3RyZWV0TmFtZSI6IkhBRExFWSBST0FEIiwicG9zdGFsQ29kZSI6IkJBMiA1QUEiLCJidWlsZGluZ051bWJlciI6IjgiLCJhZGRyZXNzTG9jYWxpdHkiOiJCQVRIIiwidmFsaWRGcm9tIjoiMjAwMC0wMS0wMSJ9XX19LCJqdGkiOiJkdW1teUp0aSJ9\\..*"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "_id": "21c7482f4853e0ca7f7a97856d4464dacf56adb4",
+      "description": "Valid credential request for old single address",
+      "providerStates": [
+        {
+          "name": "dummyApiKey is a valid api key"
+        },
+        {
+          "name": "dummyAccessToken is a valid access token"
+        },
+        {
+          "name": "test-subject is a valid subject"
+        },
+        {
+          "name": "dummyAddressComponentId is a valid issuer"
+        },
+        {
+          "name": "buildingName is 221B"
+        },
+        {
+          "name": "streetName is BAKER STREET"
+        },
+        {
+          "name": "postalCode is NW1 6XE"
+        },
+        {
+          "name": "addressLocality is LONDON"
+        },
+        {
+          "name": "validFrom is 1887-01-01"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer dummyAccessToken",
+          "x-api-key": "dummyApiKey"
+        },
+        "method": "POST",
+        "path": "/credential/issue"
+      },
+      "response": {
+        "body": "ZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKRlV6STFOaUo5LmV5SnBjM01pT2lKa2RXMXRlVUZrWkhKbGMzTkRiMjF3YjI1bGJuUkpaQ0lzSW5OMVlpSTZJblJsYzNRdGMzVmlhbVZqZENJc0ltNWlaaUk2TkRBM01Ea3dPRGd3TUN3aVpYaHdJam8wTURjd09UQTVOREF3TENKMll5STZleUowZVhCbElqcGJJbFpsY21sbWFXRmliR1ZEY21Wa1pXNTBhV0ZzSWl3aVFXUmtjbVZ6YzBOeVpXUmxiblJwWVd3aVhTd2lRR052Ym5SbGVIUWlPbHNpYUhSMGNITTZMeTkzZDNjdWR6TXViM0puTHpJd01UZ3ZZM0psWkdWdWRHbGhiSE12ZGpFaUxDSm9kSFJ3Y3pvdkwzWnZZMkZpTG1GalkyOTFiblF1WjI5MkxuVnJMMk52Ym5SbGVIUnpMMmxrWlc1MGFYUjVMWFl4TG1wemIyNXNaQ0pkTENKamNtVmtaVzUwYVdGc1UzVmlhbVZqZENJNmV5SmhaR1J5WlhOeklqcGJleUppZFdsc1pHbHVaMDVoYldVaU9pSXlNakZDSWl3aWMzUnlaV1YwVG1GdFpTSTZJa0pCUzBWU0lGTlVVa1ZGVkNJc0luQnZjM1JoYkVOdlpHVWlPaUpPVnpFZ05saEZJaXdpWVdSa2NtVnpjMHh2WTJGc2FYUjVJam9pVEU5T1JFOU9JaXdpZG1Gc2FXUkdjbTl0SWpvaU1UZzROeTB3TVMwd01TSjlYWDE5TENKcWRHa2lPaUprZFcxdGVVcDBhU0o5LnZtSnlJVl9kdHhKc21QYjNEU0ZIU2xmMkVic3J4a1ZlMUJqQ2F4Y1VHYmRVVzg0aU5raVpfaHhpYm1jY1ZHd1JUdXdnQWg5V0R3WWVRcjVMWVBoQ2JB",
+        "headers": {
+          "Content-Type": "application/jwt"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9\\.eyJpc3MiOiJkdW1teUFkZHJlc3NDb21wb25lbnRJZCIsInN1YiI6InRlc3Qtc3ViamVjdCIsIm5iZiI6NDA3MDkwODgwMCwiZXhwIjo0MDcwOTA5NDAwLCJ2YyI6eyJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiQWRkcmVzc0NyZWRlbnRpYWwiXSwiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3ZvY2FiLmFjY291bnQuZ292LnVrL2NvbnRleHRzL2lkZW50aXR5LXYxLmpzb25sZCJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJhZGRyZXNzIjpbeyJidWlsZGluZ05hbWUiOiIyMjFCIiwic3RyZWV0TmFtZSI6IkJBS0VSIFNUUkVFVCIsInBvc3RhbENvZGUiOiJOVzEgNlhFIiwiYWRkcmVzc0xvY2FsaXR5IjoiTE9ORE9OIiwidmFsaWRGcm9tIjoiMTg4Ny0wMS0wMSJ9XX19LCJqdGkiOiJkdW1teUp0aSJ9\\..*"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "_id": "103459a59ab1bf8b18a7597e40059ae05f8061b9",
+      "description": "Valid credential request for multiple addresses",
+      "providerStates": [
+        {
+          "name": "dummyApiKey is a valid api key"
+        },
+        {
+          "name": "dummyAccessToken is a valid access token"
+        },
+        {
+          "name": "test-subject is a valid subject"
+        },
+        {
+          "name": "dummyAddressComponentId is a valid issuer"
+        },
+        {
+          "name": "buildingName is 221B"
+        },
+        {
+          "name": "streetName is BAKER STREET"
+        },
+        {
+          "name": "postalCode is NW1 6XE"
+        },
+        {
+          "name": "addressLocality is LONDON"
+        },
+        {
+          "name": "validFrom is 1987-01-01"
+        },
+        {
+          "name": "second buildingName is 122"
+        },
+        {
+          "name": "second streetName is BURNS CRESCENT"
+        },
+        {
+          "name": "second postalCode is EH1 9GP"
+        },
+        {
+          "name": "second addressLocality is EDINBURGH"
+        },
+        {
+          "name": "second validFrom is 2017-01-01"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer dummyAccessToken",
+          "x-api-key": "dummyApiKey"
+        },
+        "method": "POST",
+        "path": "/credential/issue"
+      },
+      "response": {
+        "body": "ZXlKMGVYQWlPaUpLVjFRaUxDSmhiR2NpT2lKRlV6STFOaUo5LmV5SnBjM01pT2lKa2RXMXRlVUZrWkhKbGMzTkRiMjF3YjI1bGJuUkpaQ0lzSW5OMVlpSTZJblJsYzNRdGMzVmlhbVZqZENJc0ltNWlaaUk2TkRBM01Ea3dPRGd3TUN3aVpYaHdJam8wTURjd09UQTVOREF3TENKMll5STZleUowZVhCbElqcGJJbFpsY21sbWFXRmliR1ZEY21Wa1pXNTBhV0ZzSWl3aVFXUmtjbVZ6YzBOeVpXUmxiblJwWVd3aVhTd2lRR052Ym5SbGVIUWlPbHNpYUhSMGNITTZMeTkzZDNjdWR6TXViM0puTHpJd01UZ3ZZM0psWkdWdWRHbGhiSE12ZGpFaUxDSm9kSFJ3Y3pvdkwzWnZZMkZpTG1GalkyOTFiblF1WjI5MkxuVnJMMk52Ym5SbGVIUnpMMmxrWlc1MGFYUjVMWFl4TG1wemIyNXNaQ0pkTENKamNtVmtaVzUwYVdGc1UzVmlhbVZqZENJNmV5SmhaR1J5WlhOeklqcGJleUppZFdsc1pHbHVaMDVoYldVaU9pSXlNakZDSWl3aWMzUnlaV1YwVG1GdFpTSTZJa0pCUzBWU0lGTlVVa1ZGVkNJc0luQnZjM1JoYkVOdlpHVWlPaUpPVnpFZ05saEZJaXdpWVdSa2NtVnpjMHh2WTJGc2FYUjVJam9pVEU5T1JFOU9JaXdpZG1Gc2FXUkdjbTl0SWpvaU1UazROeTB3TVMwd01TSjlMSHNpWW5WcGJHUnBibWRPWVcxbElqb2lNVEl5SWl3aWMzUnlaV1YwVG1GdFpTSTZJa0pWVWs1VElFTlNSVk5EUlU1VUlpd2ljRzl6ZEdGc1EyOWtaU0k2SWtWSU1TQTVSMUFpTENKaFpHUnlaWE56VEc5allXeHBkSGtpT2lKRlJFbE9RbFZTUjBnaUxDSjJZV3hwWkVaeWIyMGlPaUl5TURFM0xUQXhMVEF4SW4xZGZYMHNJbXAwYVNJNkltUjFiVzE1U25ScEluMC5wdVlOOFRfZWRrbDBoX2E3azRaeTNGdGtOS0I1SjJacDBUSzdxcmFQbDFXRXd6czBlZTQ2SkFiMEFnR19sWUtIbG11M0hwNUpDRHpVX0dTUjZjS2tsQQ==",
+        "headers": {
+          "Content-Type": "application/jwt"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9\\.eyJpc3MiOiJkdW1teUFkZHJlc3NDb21wb25lbnRJZCIsInN1YiI6InRlc3Qtc3ViamVjdCIsIm5iZiI6NDA3MDkwODgwMCwiZXhwIjo0MDcwOTA5NDAwLCJ2YyI6eyJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiQWRkcmVzc0NyZWRlbnRpYWwiXSwiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3ZvY2FiLmFjY291bnQuZ292LnVrL2NvbnRleHRzL2lkZW50aXR5LXYxLmpzb25sZCJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJhZGRyZXNzIjpbeyJidWlsZGluZ05hbWUiOiIyMjFCIiwic3RyZWV0TmFtZSI6IkJBS0VSIFNUUkVFVCIsInBvc3RhbENvZGUiOiJOVzEgNlhFIiwiYWRkcmVzc0xvY2FsaXR5IjoiTE9ORE9OIiwidmFsaWRGcm9tIjoiMTk4Ny0wMS0wMSJ9LHsiYnVpbGRpbmdOYW1lIjoiMTIyIiwic3RyZWV0TmFtZSI6IkJVUk5TIENSRVNDRU5UIiwicG9zdGFsQ29kZSI6IkVIMSA5R1AiLCJhZGRyZXNzTG9jYWxpdHkiOiJFRElOQlVSR0giLCJ2YWxpZEZyb20iOiIyMDE3LTAxLTAxIn1dfX0sImp0aSI6ImR1bW15SnRpIn0\\..*"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "_id": "5e325f2af10e91c72fee02aec1f4dc5163fa1055",
+      "description": "Invalid credential request",
+      "providerStates": [
+        {
+          "name": "dummyApiKey is a valid api key"
+        },
+        {
+          "name": "dummyInvalidAccessToken is an invalid access token"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Authorization": "Bearer dummyInvalidAccessToken",
+          "x-api-key": "dummyApiKey"
+        },
+        "method": "POST",
+        "path": "/credential/issue"
+      },
+      "response": {
+        "status": 403
+      }
+    }
+  ],
+  "metadata": {
+    "pact-jvm": {
+      "version": "4.6.5"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "AddressCriVcProvider"
+  },
+  "createdAt": "2024-08-01T07:46:57+00:00"
+}

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -14,7 +14,8 @@ dependencies {
 			configurations.nimbus,
 			configurations.powertools,
 			configurations.sqs,
-			configurations.kms
+			configurations.kms,
+			configurations.webcompere
 
 	aspect configurations.powertools
 


### PR DESCRIPTION
## Proposed changes

Adding PACT provider tests for the VC Issue generation

### Why did it change

PACT is a requirement to test integration with the consumer which in this case is `ipv-core`

It test different address VC generation scenarios for address

1. An old address
2. A single Address with building number
3. A single Address with building name instead of building number
4. Multipe Addresses

- [OJ-2650](https://govukverify.atlassian.net/browse/OJ-2650)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2650]: https://govukverify.atlassian.net/browse/OJ-2650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ