### PR TITLE
Oj-2720: Add KID to JWT Header

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,0 +1,3 @@
+ignore_checks:
+  - E3020
+  - W1028

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "3.0.4",
+		cri_common_lib           : "3.0.5",
 		pact_provider_version	 : "4.5.11",
 		webcompere_version       : "2.1.6",
 		slf4j_log4j12_version    : "2.0.13", // For contract test debug

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "3.0.3",
+		cri_common_lib           : "3.0.4",
 		pact_provider_version	 : "4.5.11",
 		webcompere_version       : "2.1.6",
 		slf4j_log4j12_version    : "2.0.13", // For contract test debug

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -274,6 +274,12 @@ Resources:
               Principal: '*'
               Resource:
                 - 'execute-api:/*'
+              Condition:
+                StringNotEquals:
+                  aws:SourceVpce: !If
+                    - IsDevEnvironment
+                    - vpce-082cab7c78139eb54
+                    - !ImportValue cri-vpc-ApiGatewayVpcEndpointId
 
   DevOnlyAddressApi:
     Type: AWS::Serverless::Api
@@ -740,6 +746,7 @@ Resources:
         - !ImportValue core-infrastructure-AlarmTopic
       InsufficientDataActions: []
       DatapointsToAlarm: 3
+      Dimensions: []
       EvaluationPeriods: 3
       Threshold: 1
       ComparisonOperator: GreaterThanThreshold

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -274,12 +274,6 @@ Resources:
               Principal: '*'
               Resource:
                 - 'execute-api:/*'
-              Condition:
-                StringNotEquals:
-                  aws:SourceVpce: !If
-                    - IsDevEnvironment
-                    - vpce-082cab7c78139eb54
-                    - !ImportValue cri-vpc-ApiGatewayVpcEndpointId
 
   DevOnlyAddressApi:
     Type: AWS::Serverless::Api
@@ -745,7 +739,6 @@ Resources:
       OKActions:
         - !ImportValue core-infrastructure-AlarmTopic
       InsufficientDataActions: []
-      Dimensions: []
       DatapointsToAlarm: 3
       EvaluationPeriods: 3
       Threshold: 1

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -141,7 +141,9 @@ public class AddressSteps {
         final var payloadValue = decodedJWT.getPayload().toString();
         final var payload = objectMapper.readTree(payloadValue);
 
-        assertEquals("{\"typ\":\"JWT\",\"alg\":\"ES256\"}", header);
+        assertEquals(
+                "{\"typ\":\"JWT\",\"alg\":\"ES256\",\"kid\":\"did:web:review-a.dev.account.gov.uk#1753cf0b1e3647d91719820b74cf0c4f08782d0f072ebaf5ec4ee0873436a7ab\"}",
+                header);
 
         assertNotNull(payload);
         assertNotNull(payload.get("nbf"));

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -137,13 +137,15 @@ public class AddressSteps {
     }
 
     private void makeAssertions(SignedJWT decodedJWT) throws IOException {
-        final var header = decodedJWT.getHeader().toString();
+        final var header = objectMapper.readTree(decodedJWT.getHeader().toString());
         final var payloadValue = decodedJWT.getPayload().toString();
         final var payload = objectMapper.readTree(payloadValue);
 
+        assertEquals("JWT", header.at("/typ").asText());
+        assertEquals("ES256", header.at("/alg").asText());
         assertEquals(
-                "{\"typ\":\"JWT\",\"alg\":\"ES256\",\"kid\":\"did:web:review-a.dev.account.gov.uk#1753cf0b1e3647d91719820b74cf0c4f08782d0f072ebaf5ec4ee0873436a7ab\"}",
-                header);
+                "did:web:review-a.dev.account.gov.uk#77618cc9ebd6909cbf0b50b00126f8e7feb5dbfdb64e6c623c01a6cafca47e41",
+                header.at("/kid").asText());
 
         assertNotNull(payload);
         assertNotNull(payload.get("nbf"));

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/objectmapper/CustomObjectMapper.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/objectmapper/CustomObjectMapper.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jwt.JWTClaimsSet;
 import uk.gov.di.ipv.cri.address.api.objectmapper.mixin.AddressMixIn;
 import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
@@ -27,6 +28,7 @@ public class CustomObjectMapper {
 
         SimpleModule module = new SimpleModule();
         module.addSerializer(JWTClaimsSet.class, new JWTClaimsSetSerializer());
+        module.addSerializer(JWSHeader.class, new JWSHeaderSerializer());
         objectMapper.registerModule(module);
 
         return objectMapper;

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/objectmapper/JWSHeaderSerializer.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/objectmapper/JWSHeaderSerializer.java
@@ -1,0 +1,30 @@
+package uk.gov.di.ipv.cri.address.api.objectmapper;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.nimbusds.jose.JWSHeader;
+
+import java.io.IOException;
+
+public class JWSHeaderSerializer extends JsonSerializer<JWSHeader> {
+    @Override
+    public void serialize(JWSHeader header, JsonGenerator gen, SerializerProvider serializers)
+            throws IOException {
+        gen.writeStartObject();
+
+        if (header.getType() != null) {
+            gen.writeStringField("typ", header.getType().toString());
+        } else {
+            gen.writeStringField("typ", "JWT");
+        }
+        if (header.getAlgorithm() != null) {
+            gen.writeStringField("alg", header.getAlgorithm().getName());
+        }
+        if (header.getKeyID() != null) {
+            gen.writeStringField("kid", header.getKeyID());
+        }
+
+        gen.writeEndObject();
+    }
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialService.java
@@ -54,7 +54,7 @@ public class VerifiableCredentialService {
                                 Map.of(VC_ADDRESS_KEY, convertAddresses(canonicalAddresses)))
                         .build();
 
-        return signedJwtFactory.createSignedJwt(objectMapper.writeValueAsString(claimsSet));
+        return signedJwtFactory.createSignedJwt(claimsSet);
     }
 
     public Map<String, Object> getAuditEventExtensions(List<CanonicalAddress> addresses) {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialService.java
@@ -56,7 +56,8 @@ public class VerifiableCredentialService {
         return signedJwtFactory.createSignedJwt(
                 claimsSet,
                 configurationService.getVerifiableCredentialIssuer(),
-                configurationService.getVerifiableCredentialKmsSigningKeyId());
+                configurationService.getCommonParameterValue(
+                        "verifiableCredentialKmsSigningKeyId"));
     }
 
     public Map<String, Object> getAuditEventExtensions(List<CanonicalAddress> addresses) {

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialService.java
@@ -1,6 +1,5 @@
 package uk.gov.di.ipv.cri.address.api.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.SignedJWT;
@@ -9,7 +8,7 @@ import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.util.SignedJWTFactory;
 import uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder;
 
-import java.text.ParseException;
+import java.security.NoSuchAlgorithmException;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +39,7 @@ public class VerifiableCredentialService {
 
     public SignedJWT generateSignedVerifiableCredentialJwt(
             String subject, List<CanonicalAddress> canonicalAddresses)
-            throws JOSEException, JsonProcessingException, ParseException {
+            throws NoSuchAlgorithmException, JOSEException {
         long jwtTtl = this.configurationService.getMaxJwtTtl();
         ChronoUnit jwtTtlUnit =
                 ChronoUnit.valueOf(this.configurationService.getParameterValue("JwtTtlUnit"));
@@ -54,7 +53,10 @@ public class VerifiableCredentialService {
                                 Map.of(VC_ADDRESS_KEY, convertAddresses(canonicalAddresses)))
                         .build();
 
-        return signedJwtFactory.createSignedJwt(claimsSet);
+        return signedJwtFactory.createSignedJwt(
+                claimsSet,
+                configurationService.getVerifiableCredentialIssuer(),
+                configurationService.getVerifiableCredentialKmsSigningKeyId());
     }
 
     public Map<String, Object> getAuditEventExtensions(List<CanonicalAddress> addresses) {

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandlerTest.java
@@ -215,7 +215,8 @@ class IssueCredentialHandlerTest {
         SignedJWTFactory signedJwtFactory = new SignedJWTFactory(new ECDSASigner(getPrivateKey()));
         ConfigurationService mockConfigurationService = mock(ConfigurationService.class);
         when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn("dummy-issuer");
-        when(mockConfigurationService.getVerifiableCredentialKmsSigningKeyId())
+        when(mockConfigurationService.getCommonParameterValue(
+                        "verifiableCredentialKmsSigningKeyId"))
                 .thenReturn(EC_PRIVATE_KEY_1);
         when(mockConfigurationService.getMaxJwtTtl()).thenReturn(10L);
         when(mockConfigurationService.getParameterValue("JwtTtlUnit")).thenReturn("MINUTES");

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/MultipleAddressVcTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/MultipleAddressVcTest.java
@@ -61,6 +61,7 @@ import java.util.UUID;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.address.api.handler.pact.util.JwtSigner.getEcdsaSigner;
 import static uk.gov.di.ipv.cri.address.api.objectmapper.CustomObjectMapper.getMapperWithCustomSerializers;
+import static uk.gov.di.ipv.cri.address.api.service.fixtures.TestFixtures.EC_PRIVATE_KEY_1;
 import static uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder.ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID;
 
 @Tag("Pact")
@@ -164,6 +165,8 @@ class MultipleAddressVcTest implements DummyStates, MultipleAddressStates {
         when(mockAddressService.getAddressItem(sessionId)).thenReturn(addressItem);
         when(mockConfigurationService.getVerifiableCredentialIssuer())
                 .thenReturn("dummyAddressComponentId");
+        when(mockConfigurationService.getVerifiableCredentialKmsSigningKeyId())
+                .thenReturn(EC_PRIVATE_KEY_1);
         when(mockConfigurationService.getMaxJwtTtl()).thenReturn(10L);
         when(mockConfigurationService.getParameterValue("JwtTtlUnit")).thenReturn("MINUTES");
     }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/MultipleAddressVcTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/MultipleAddressVcTest.java
@@ -165,7 +165,8 @@ class MultipleAddressVcTest implements DummyStates, MultipleAddressStates {
         when(mockAddressService.getAddressItem(sessionId)).thenReturn(addressItem);
         when(mockConfigurationService.getVerifiableCredentialIssuer())
                 .thenReturn("dummyAddressComponentId");
-        when(mockConfigurationService.getVerifiableCredentialKmsSigningKeyId())
+        when(mockConfigurationService.getCommonParameterValue(
+                        "verifiableCredentialKmsSigningKeyId"))
                 .thenReturn(EC_PRIVATE_KEY_1);
         when(mockConfigurationService.getMaxJwtTtl()).thenReturn(10L);
         when(mockConfigurationService.getParameterValue("JwtTtlUnit")).thenReturn("MINUTES");

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/SingleAddressBuildNumberVcTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/SingleAddressBuildNumberVcTest.java
@@ -62,6 +62,7 @@ import java.util.UUID;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.address.api.handler.pact.util.JwtSigner.getEcdsaSigner;
 import static uk.gov.di.ipv.cri.address.api.objectmapper.CustomObjectMapper.getMapperWithCustomSerializers;
+import static uk.gov.di.ipv.cri.address.api.service.fixtures.TestFixtures.EC_PRIVATE_KEY_1;
 import static uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder.ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID;
 
 @Tag("Pact")
@@ -163,6 +164,8 @@ class SingleAddressBuildNumberVcTest implements DummyStates, SingleAddressBuildi
         when(mockAddressService.getAddressItem(sessionId)).thenReturn(addressItem);
         when(mockConfigurationService.getVerifiableCredentialIssuer())
                 .thenReturn("dummyAddressComponentId");
+        when(mockConfigurationService.getVerifiableCredentialKmsSigningKeyId())
+                .thenReturn(EC_PRIVATE_KEY_1);
         when(mockConfigurationService.getMaxJwtTtl()).thenReturn(10L);
         when(mockConfigurationService.getParameterValue("JwtTtlUnit")).thenReturn("MINUTES");
     }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/SingleAddressBuildNumberVcTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/SingleAddressBuildNumberVcTest.java
@@ -164,7 +164,8 @@ class SingleAddressBuildNumberVcTest implements DummyStates, SingleAddressBuildi
         when(mockAddressService.getAddressItem(sessionId)).thenReturn(addressItem);
         when(mockConfigurationService.getVerifiableCredentialIssuer())
                 .thenReturn("dummyAddressComponentId");
-        when(mockConfigurationService.getVerifiableCredentialKmsSigningKeyId())
+        when(mockConfigurationService.getCommonParameterValue(
+                        "verifiableCredentialKmsSigningKeyId"))
                 .thenReturn(EC_PRIVATE_KEY_1);
         when(mockConfigurationService.getMaxJwtTtl()).thenReturn(10L);
         when(mockConfigurationService.getParameterValue("JwtTtlUnit")).thenReturn("MINUTES");

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/SingleAddressBuildingNameVcTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/SingleAddressBuildingNameVcTest.java
@@ -62,6 +62,7 @@ import java.util.UUID;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.address.api.handler.pact.util.JwtSigner.getEcdsaSigner;
 import static uk.gov.di.ipv.cri.address.api.objectmapper.CustomObjectMapper.getMapperWithCustomSerializers;
+import static uk.gov.di.ipv.cri.address.api.service.fixtures.TestFixtures.EC_PRIVATE_KEY_1;
 import static uk.gov.di.ipv.cri.common.library.util.VerifiableCredentialClaimsSetBuilder.ENV_VAR_FEATURE_FLAG_VC_CONTAINS_UNIQUE_ID;
 
 @Tag("Pact")
@@ -131,6 +132,8 @@ class SingleAddressBuildingNameVcTest implements DummyStates, SingleAddressBuild
                 new VerifiableCredentialClaimsSetBuilder(mockConfigurationService, clock);
         claimsSetBuilder.overrideJti("dummyJti");
 
+        when(mockConfigurationService.getVerifiableCredentialIssuer())
+                .thenReturn("dummyAddressComponentId");
         verifiableCredentialService =
                 new VerifiableCredentialService(
                         signedJwtFactory, mockConfigurationService, objectMapper, claimsSetBuilder);
@@ -161,9 +164,9 @@ class SingleAddressBuildingNameVcTest implements DummyStates, SingleAddressBuild
         when(mockSessionService.getSessionByAccessToken(accessToken)).thenReturn(getSessionItem());
         AddressItem addressItem = new AddressItem();
         addressItem.setAddresses(getCanonicalAddresses());
+        when(mockConfigurationService.getVerifiableCredentialKmsSigningKeyId())
+                .thenReturn(EC_PRIVATE_KEY_1);
         when(mockAddressService.getAddressItem(sessionId)).thenReturn(addressItem);
-        when(mockConfigurationService.getVerifiableCredentialIssuer())
-                .thenReturn("dummyAddressComponentId");
         when(mockConfigurationService.getMaxJwtTtl()).thenReturn(10L);
         when(mockConfigurationService.getParameterValue("JwtTtlUnit")).thenReturn("MINUTES");
     }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/SingleAddressBuildingNameVcTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/SingleAddressBuildingNameVcTest.java
@@ -164,7 +164,8 @@ class SingleAddressBuildingNameVcTest implements DummyStates, SingleAddressBuild
         when(mockSessionService.getSessionByAccessToken(accessToken)).thenReturn(getSessionItem());
         AddressItem addressItem = new AddressItem();
         addressItem.setAddresses(getCanonicalAddresses());
-        when(mockConfigurationService.getVerifiableCredentialKmsSigningKeyId())
+        when(mockConfigurationService.getCommonParameterValue(
+                        "verifiableCredentialKmsSigningKeyId"))
                 .thenReturn(EC_PRIVATE_KEY_1);
         when(mockAddressService.getAddressItem(sessionId)).thenReturn(addressItem);
         when(mockConfigurationService.getMaxJwtTtl()).thenReturn(10L);

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/util/PreLambdaHandler.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/pact/util/PreLambdaHandler.java
@@ -154,11 +154,12 @@ public class PreLambdaHandler implements HttpHandler {
             LOGGER.info("getting response body");
             String body = response.getBody();
             if (response.getStatusCode() == 200) {
-                body = reOrderJwt(response.getBody());
+                body = reOrderJwt(body);
             }
-            exchange.sendResponseHeaders(statusCode, response.getBody().length());
+            byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(statusCode, bodyBytes.length);
             try (OutputStream os = exchange.getResponseBody()) {
-                os.write(body.getBytes());
+                os.write(bodyBytes);
             }
         }
     }

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialServiceTest.java
@@ -77,7 +77,8 @@ class VerifiableCredentialServiceTest implements TestFixtures {
         initMockVCClaimSetBuilder();
         when(mockVcClaimSetBuilder.build()).thenReturn(TEST_CLAIMS_SET);
         when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(VC_ISSUER);
-        when(mockConfigurationService.getVerifiableCredentialKmsSigningKeyId())
+        when(mockConfigurationService.getCommonParameterValue(
+                        "verifiableCredentialKmsSigningKeyId"))
                 .thenReturn(EC_PRIVATE_KEY_1);
 
         var canonicalAddresses = List.of(mock(CanonicalAddress.class));
@@ -96,7 +97,8 @@ class VerifiableCredentialServiceTest implements TestFixtures {
         initMockVCClaimSetBuilder();
         when(mockVcClaimSetBuilder.build()).thenReturn(TEST_CLAIMS_SET);
         when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(VC_ISSUER);
-        when(mockConfigurationService.getVerifiableCredentialKmsSigningKeyId())
+        when(mockConfigurationService.getCommonParameterValue(
+                        "verifiableCredentialKmsSigningKeyId"))
                 .thenReturn(EC_PRIVATE_KEY_1);
 
         CanonicalAddress address = new CanonicalAddress();

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialServiceTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialServiceTest.java
@@ -95,6 +95,7 @@ class VerifiableCredentialServiceTest implements TestFixtures {
         initMockConfigurationService();
         initMockVCClaimSetBuilder();
         when(mockVcClaimSetBuilder.build()).thenReturn(TEST_CLAIMS_SET);
+        when(mockConfigurationService.getVerifiableCredentialIssuer()).thenReturn(VC_ISSUER);
         when(mockConfigurationService.getVerifiableCredentialKmsSigningKeyId())
                 .thenReturn(EC_PRIVATE_KEY_1);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Add KID to JWT Header

### What changed

<!-- Describe the changes in detail - the "what"-->
Bump cri_common_lib 3.0.3 -> 3.0.4 -> 3.0.5

Updated VerifiableCredentialService to use the new jwt signing method.

Updated IssueCredentialHandler to handle the NoSuchAlgorithmException. We opted to treat is as a 500 internal error. It is thrown from the new cri-lib method, but it would be very unusal to be thrown especially once pre-merge tests have ran. If this exception is ever thrown we may want to look at a different way to handle it.

Added JWSHeaderSerializer in the PreLambdaHandler, this is to be able to explicitly specify the order of the JWSHeader fields
{
  "alg": "HS256",
  "typ": "JWT",
  "kid": "kid-value"
}

Added and updated unit/pact tests for the above.


### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2720](https://govukverify.atlassian.net/browse/OJ-2720)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2720]: https://govukverify.atlassian.net/browse/OJ-2720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ