### PR TITLE
replace rusty-actions with dev-platform action

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -49,27 +49,14 @@ jobs:
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/lambda/template.yaml
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./infrastructure/lambda/template.yaml
-          profile: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
-
       - name: SAM build
-        run: sam build -t infrastructure/lambda/template.yaml
-
-      - name: SAM package
         run: |
-          sam package \
-            ${{ steps.signing.outputs.signing_config }} \
-            --s3-bucket ${{ secrets.DEV_CRI_V1_ARTIFACT_SOURCE_BUCKET_NAME }} \
-            --region ${{ env.AWS_REGION }} --output-template-file=cf-template.yaml
+          mkdir out
+          sam build -t ./infrastructure/lambda/template.yaml -b ./out/
 
-      - name: Zip the CloudFormation template
-        run: zip template.zip cf-template.yaml
-
-      - name: Upload zipped CloudFormation artifact to S3
-        env:
-          DEV_ARTIFACT_SOURCE_BUCKET_NAME: ${{ secrets.DEV_CRI_V1_ARTIFACT_SOURCE_BUCKET_NAME }}
-        run: aws s3 cp template.zip "s3://$DEV_ARTIFACT_SOURCE_BUCKET_NAME/template.zip"
+      - name: Deploy SAM app
+        uses: govuk-one-login/devplatform-upload-action@v3.9.1
+        with:
+          artifact-bucket-name: ${{ secrets.DEV_CRI_V1_ARTIFACT_SOURCE_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
+          working-directory: ./out

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -46,30 +46,17 @@ jobs:
           role-to-assume: ${{ secrets.BUILD_CRI_V1_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Generate code signing config
-        id: signing
-        uses: rusty-actions/sam-code-signing-config@1c9d03c875b42b34b5ecc68a9d219f583782bbfc
-        with:
-          template: ./infrastructure/lambda/template.yaml
-          profile: ${{ secrets.BUILD_SIGNING_PROFILE_NAME }}
-
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/lambda/template.yaml
 
       - name: SAM build
-        run: sam build -t infrastructure/lambda/template.yaml
-
-      - name: SAM package
         run: |
-          sam package \
-            ${{ steps.signing.outputs.signing_config }} \
-            --s3-bucket ${{ secrets.BUILD_CRI_V1_ARTIFACT_SOURCE_BUCKET_NAME }} \
-            --region ${{ env.AWS_REGION }} --output-template-file=cf-template.yaml
+          mkdir out
+          sam build -t ./infrastructure/lambda/template.yaml -b ./out/
 
-      - name: Zip the CloudFormation template
-        run: zip template.zip cf-template.yaml
-
-      - name: Upload zipped CloudFormation artifact to S3
-        env:
-          ARTIFACT_SOURCE_BUCKET_NAME: ${{ secrets.BUILD_CRI_V1_ARTIFACT_SOURCE_BUCKET_NAME }}
-        run: aws s3 cp template.zip "s3://$ARTIFACT_SOURCE_BUCKET_NAME/template.zip"
+      - name: Deploy SAM app
+        uses: govuk-one-login/devplatform-upload-action@v3.9.1
+        with:
+          artifact-bucket-name: ${{ secrets.BUILD_CRI_V1_ARTIFACT_SOURCE_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE_NAME }}
+          working-directory: ./out


### PR DESCRIPTION
## Proposed changes

### What changed

Tested using dev platform upload action in dev workflow ahead of applying it to the build workflow
Post test added change for build as well

### Why did it change

The rusty-action action is is no longer maintained and the dev platform have an action that handles the same functionality.

### Issue tracking

- [IPS-503](https://govukverify.atlassian.net/browse/IPS-503)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations:
- Pacts are failing in the dev workflow but this PR does not make any changes to cause this issue

### Screenshots
![Screenshot 2024-08-19 at 11 47 27](https://github.com/user-attachments/assets/113da53b-22d1-4ccc-a186-b3791a71ed3e)

![Screenshot 2024-08-19 at 11 49 24](https://github.com/user-attachments/assets/b2ec913c-f7b5-4572-9493-7f3a470dc51b)


[IPS-503]: https://govukverify.atlassian.net/browse/IPS-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ