### PR TITLE
OJ-2745: Add API response metrics and logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "3.0.5",
+		cri_common_lib           : "3.0.6",
 		pact_provider_version	 : "4.5.11",
 		webcompere_version       : "2.1.6",
 		slf4j_log4j12_version    : "2.0.13", // For contract test debug

--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
@@ -84,14 +84,15 @@ public class PostcodeLookupHandler
                         .connectTimeout(Duration.ofSeconds(CONNECTION_TIMEOUT_SECONDS))
                         .build();
 
+        this.eventProbe = new EventProbe();
+
         this.postcodeLookupService =
-                new PostcodeLookupService(configurationService, httpClient, LogManager.getLogger());
+                new PostcodeLookupService(
+                        configurationService, httpClient, LogManager.getLogger(), eventProbe);
 
         this.sessionService =
                 new SessionService(
                         configurationService, clientProviderFactory.getDynamoDbEnhancedClient());
-
-        this.eventProbe = new EventProbe();
 
         this.auditService =
                 new AuditService(

--- a/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
+++ b/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
@@ -14,7 +14,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import software.amazon.awssdk.http.HttpStatusCode;
+import software.amazon.cloudwatchlogs.emf.model.Unit;
 import uk.gov.di.ipv.cri.address.api.exceptions.PostcodeLookupBadRequestException;
 import uk.gov.di.ipv.cri.address.api.exceptions.PostcodeLookupProcessingException;
 import uk.gov.di.ipv.cri.address.api.exceptions.PostcodeLookupTimeoutException;
@@ -22,6 +24,7 @@ import uk.gov.di.ipv.cri.address.api.exceptions.PostcodeValidationException;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventContext;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
 import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 
 import java.io.IOException;
 import java.net.URI;
@@ -30,6 +33,8 @@ import java.net.http.HttpConnectTimeoutException;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -42,7 +47,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,8 +55,37 @@ class PostcodeLookupServiceTest {
     @Mock private HttpResponse<String> mockResponse;
     @Spy private HttpClient httpClient;
     @Mock private Logger log;
+    @Mock private EventProbe eventProbe;
     @Captor private ArgumentCaptor<HttpRequest> postCodeRequest;
     @InjectMocks private PostcodeLookupService postcodeLookupService;
+
+    @Test
+    void shouldLogAPILatency() throws IOException, InterruptedException {
+        long mockLatency = 100;
+
+        when(mockConfigurationService.getParameterValue("OrdnanceSurveyAPIURL"))
+                .thenReturn("http://localhost:8080/");
+        when(mockResponse.statusCode()).thenReturn(HttpStatusCode.OK);
+        when(mockResponse.body())
+                .thenReturn(
+                        "{\"header\":{\"uri\":\"http://localhost:8080/postcode?postcode=ZZ1+1ZZ\",\"query\":\"postcode=ZZ11ZZ\",\"offset\":0,\"totalresults\":32,\"format\":\"JSON\",\"dataset\":\"DPA\",\"lr\":\"EN,CY\",\"maxresults\":1000,\"epoch\":\"90\",\"output_srs\":\"EPSG:27700\"},\"results\":[{\"DPA\":{\"UPRN\":\"12345567\",\"UDPRN\":\"12345678\",\"ADDRESS\":\"TESTADDRESS,TESTSTREET,TESTTOWN,ZZ11ZZ\",\"BUILDING_NUMBER\":\"TESTADDRESS\",\"THOROUGHFARE_NAME\":\"TESTSTREET\",\"POST_TOWN\":\"TESTTOWN\",\"POSTCODE\":\"ZZ11ZZ\",\"RPC\":\"1\",\"X_COORDINATE\":123456.78,\"Y_COORDINATE\":234567.89,\"STATUS\":\"APPROVED\",\"LOGICAL_STATUS_CODE\":\"1\",\"CLASSIFICATION_CODE\":\"RD03\",\"CLASSIFICATION_CODE_DESCRIPTION\":\"Semi-Detached\",\"LOCAL_CUSTODIAN_CODE\":1234,\"LOCAL_CUSTODIAN_CODE_DESCRIPTION\":\"TESTTOWN\",\"COUNTRY_CODE\":\"E\",\"COUNTRY_CODE_DESCRIPTION\":\"ThisrecordiswithinEngland\",\"POSTAL_ADDRESS_CODE\":\"D\",\"POSTAL_ADDRESS_CODE_DESCRIPTION\":\"ArecordwhichislinkedtoPAF\",\"BLPU_STATE_CODE\":\"2\",\"BLPU_STATE_CODE_DESCRIPTION\":\"Inuse\",\"TOPOGRAPHY_LAYER_TOID\":\"osgb12345567890\",\"LAST_UPDATE_DATE\":\"10/02/2016\",\"ENTRY_DATE\":\"12/01/2000\",\"BLPU_STATE_DATE\":\"15/06/2009\",\"LANGUAGE\":\"EN\",\"MATCH\":1.0,\"MATCH_DESCRIPTION\":\"EXACT\",\"DELIVERY_POINT_SUFFIX\":\"1A\"}}]}");
+
+        /* Add a latency of 100ms to the API request */
+        when(httpClient.send(
+                        any(HttpRequest.class),
+                        ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+                .thenAnswer(
+                        (Answer<HttpResponse<String>>)
+                                invocation -> {
+                                    new CountDownLatch(1).await(mockLatency, TimeUnit.MILLISECONDS);
+                                    return mockResponse;
+                                });
+
+        postcodeLookupService.lookupPostcode("ZZ1 1ZZ");
+
+        verify(eventProbe, times(1))
+                .counterMetric("lookup_postcode_duration", mockLatency, Unit.MILLISECONDS);
+    }
 
     @Nested
     class PostCodeLookUpServiceRequestExceptionTest {
@@ -275,7 +308,12 @@ class PostcodeLookupServiceTest {
                     .thenReturn(mockResponse);
 
             assertTrue(postcodeLookupService.lookupPostcode("ZZ1 1ZZ").isEmpty());
-            verifyNoInteractions(log);
+            verify(log, times(1))
+                    .info(
+                            "API response received: url={}, status={}, latencyInMs={}",
+                            "http://localhost:8080/?postcode=ZZ1%201ZZ&key",
+                            HttpStatusCode.OK,
+                            0L);
         }
 
         @Test


### PR DESCRIPTION
## Proposed changes

### What changed
`PostcodeLookupService` added a metric `lookup_postcode_duration` to measure the latency between third-party API calls.

### Why did it change
This change was added so that we have visibility of how long our API calls to third-parties takes. Primarily, this is to aid bottlenecks in our system.

**Screenshot**
![image](https://github.com/user-attachments/assets/c0a1bd48-326d-4f6d-a70f-6a5656e5dfc9)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2745](https://govukverify.atlassian.net/browse/OJ-2745)


[OJ-2745]: https://govukverify.atlassian.net/browse/OJ-2745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ