### PR TITLE
OJ-2778: address resolve linting

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,3 +1,0 @@
-ignore_checks:
-  - E3020
-  - W1028

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -276,10 +276,7 @@ Resources:
                 - 'execute-api:/*'
               Condition:
                 StringNotEquals:
-                  aws:SourceVpce: !If
-                    - IsDevEnvironment
-                    - vpce-082cab7c78139eb54
-                    - !ImportValue cri-vpc-ApiGatewayVpcEndpointId
+                  aws:SourceVpce: !ImportValue cri-vpc-ApiGatewayVpcEndpointId
 
   DevOnlyAddressApi:
     Type: AWS::Serverless::Api
@@ -746,7 +743,6 @@ Resources:
         - !ImportValue core-infrastructure-AlarmTopic
       InsufficientDataActions: []
       DatapointsToAlarm: 3
-      Dimensions: []
       EvaluationPeriods: 3
       Threshold: 1
       ComparisonOperator: GreaterThanThreshold


### PR DESCRIPTION
## Proposed changes
see: 
```
Check Fn::If has a path that cannot be reached] (['Fn::If', 1] is not reachable. 
When setting condition 'IsDevEnvironment' to True. Where existing status for condition `IsNotDevEnvironment` is True)
```

The basically saying the condition `IsDevEnvironment` is never used because of the condition IsNotDevEnvironment applied when the resource is defined therefore the IsDevEnvironment can be removed entirely.

Also removed `Dimensions: []` as flagged by linter

Remove `.cfnlintrc` this was temporary way to ignore the linting issues. due to upgrade of SAM CLI to version 1.123.0 
in the github Action

**NB**
See: https://govukverify.atlassian.net/browse/OJ-2255 which is a related ticket, that's outside the scope of this one.
The `DEV` stack for KBV and ADDRESS are actually more like the LOCALDEV stack `DEV` in Check Nino CRI which is where we should be for Address and KBV at some point that's what OJ-2255 is for