### PR TITLE
IPS-1086 address api lambda canary deployment set

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ Build with `./gradlew`
 
 This will run "build", "test", "buildZip", and "spotLess" reformatting
 
+## Canaries
+When deploying using sam deploy, canary deployment strategy will be used which is set in LambdaDeploymentPreference in template.yaml file. 
+
+When deploying using the pipeline, canary deployment strategy set in the pipeline will be used and override the default set in template.yaml. 
+
+Canary deployments will cause a rollback if any canary alarms associated with a lambda are triggered. 
+
+To skip canaries such as when releasing urgent changes to production, set the last commit message to contain either of these phrases: [skip canary], [canary skip], or [no canary] as specified in the [Canary Escape Hatch guide](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3836051600/Rollback+Recovery+Guidance#Escape-Hatch%3A-how-to-skip-canary-deployments-when-needed). 
+`git commit -m "some message [skip canary]"`
+
+Note: To update LambdaDeploymentPreference, update the LambdaCanaryDeployment pipeline parameter in the [identity-common-infra repository](https://github.com/govuk-one-login/identity-common-infra/tree/main/terraform/orange/address). To update the LambdaDeploymentPreference for a stack in dev using sam deploy, parameter override needs to be set in the [deploy script](./deploy.sh). 
+`--parameter-overrides LambdaDeploymentPreference=<define-strategy> \`
+
 ## Deploy to dev account
 
 Ensure you have the `sam-cli` and `gds-cli` installed, and that you can assume an admin role on the ` di-ipv-cri-address-dev` AWS account.

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -838,6 +838,12 @@ Resources:
       Dimensions:
         - Name: ApiName
           Value: !Sub "${AWS::StackName}-PrivateAddressApi"
+        - Name: Method
+          Value: GET
+        - Name: Stage
+          Value: !Ref Environment
+        - Name: Resource
+          Value: /postcode-lookup/{postcode}
       Statistic: Sum
       Unit: Count
       Period: 60
@@ -886,6 +892,12 @@ Resources:
       Dimensions:
         - Name: ApiName
           Value: !Sub "${AWS::StackName}-PrivateAddressApi"
+        - Name: Method
+          Value: PUT
+        - Name: Stage
+          Value: !Ref Environment
+        - Name: Resource
+          Value: /address
       Statistic: Sum
       Unit: Count
       Period: 60
@@ -934,6 +946,12 @@ Resources:
       Dimensions:
         - Name: ApiName
           Value: !Sub "${AWS::StackName}-PrivateAddressApi"
+        - Name: Method
+          Value: GET
+        - Name: Stage
+          Value: !Ref Environment
+        - Name: Resource
+          Value: /addresses
       Statistic: Sum
       Unit: Count
       Period: 60

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -495,6 +495,7 @@ Resources:
       DeploymentPreference:
         Alarms:
           - !Ref IssueCredentialFunctionCanaryErrors
+          - !Ref IssueCredentialFunctionCanary5xxErrors
       CodeUri: ../../lambdas/issuecredential
       Environment:
         Variables:
@@ -978,6 +979,34 @@ Resources:
         - Name: ExecutedVersion
           Value: !GetAtt IssueCredentialFunction.Version.Version
       Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  IssueCredentialFunctionCanary5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: false
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "IssueCredential Lambda returning 5xx response."
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName}-PublicAddressApi"
+        - Name: Method
+          Value: POST
+        - Name: Stage
+          Value: !Ref Environment
+        - Name: Resource
+          Value: /credential/issue
       Statistic: Sum
       Unit: Count
       Period: 60

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -18,6 +18,10 @@ Parameters:
       - "integration"
       - "production"
     ConstraintDescription: must be dev, build, staging, integration or production
+  LambdaDeploymentPreference:
+    Description: "Specifies the configuration to enable gradual Lambda deployments"
+    Type: String
+    Default: AllAtOnce
   PermissionsBoundary:
     Description: "The ARN of the permissions boundary to apply when creating IAM roles"
     Type: String
@@ -106,6 +110,10 @@ Globals:
         - '{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}' # or NODEJS_LAYER or PYTHON_LAYER
         - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
     AutoPublishAlias: live
+    DeploymentPreference:
+      Enabled: true
+      Type: !Ref LambdaDeploymentPreference
+      Role: !GetAtt CodeDeployServiceRole.Arn
     ProvisionedConcurrencyConfig:
       !If
       - AddProvisionedConcurrency
@@ -363,6 +371,10 @@ Resources:
     Properties:
       CodeUri: ../../lambdas/postcode-lookup
       Handler: uk.gov.di.ipv.cri.address.api.handler.PostcodeLookupHandler::handleRequest
+      DeploymentPreference:
+        Alarms:
+          - !Ref PostcodeLookupFunctionCanaryErrors
+          - !Ref PostcodeLookupFunctionCanary5xxErrors
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-postcode-lookup"
@@ -432,6 +444,10 @@ Resources:
     Properties:
       CodeUri: ../../lambdas/address
       Handler: uk.gov.di.ipv.cri.address.api.handler.AddressHandler::handleRequest
+      DeploymentPreference:
+        Alarms:
+          - !Ref AddressFunctionCanaryErrors
+          - !Ref AddressFunctionCanary5xxErrors
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-address"
@@ -476,6 +492,9 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: uk.gov.di.ipv.cri.address.api.handler.IssueCredentialHandler::handleRequest
+      DeploymentPreference:
+        Alarms:
+          - !Ref IssueCredentialFunctionCanaryErrors
       CodeUri: ../../lambdas/issuecredential
       Environment:
         Variables:
@@ -535,6 +554,10 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: app.lambdaHandler
+      DeploymentPreference:
+        Alarms:
+          - !Ref GetAddressesFunctionCanaryErrors
+          - !Ref GetAddressesFunctionCanary5xxErrors
       CodeUri: ../../lambdas/get-addresses/
       Runtime: nodejs18.x
       Environment:
@@ -774,6 +797,194 @@ Resources:
                   Value: !Sub "${AWS::StackName}-PrivateAddressApi"
             Period: 300
             Stat: Sum
+
+  PostcodeLookupFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: false
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the PostcodeLookupFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-PostcodeLookupFunction:live"
+        - Name: FunctionName
+          Value: !Ref PostcodeLookupFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt PostcodeLookupFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  PostcodeLookupFunctionCanary5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: false
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "PostcodeLookupFunction Lambda returning 5xx response."
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName}-PrivateAddressApi"
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  AddressFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: false
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the AddressFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-AddressFunction:live"
+        - Name: FunctionName
+          Value: !Ref AddressFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt AddressFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  AddressFunctionCanary5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: false
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "AddressFunction Lambda returning 5xx response."
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName}-PrivateAddressApi"
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  GetAddressesFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: false
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the GetAddressesFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-GetAddressesFunction:live"
+        - Name: FunctionName
+          Value: !Ref GetAddressesFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt GetAddressesFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  GetAddressesFunctionCanary5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: false
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "GetAddressesFunction Lambda returning 5xx response."
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: ApiName
+          Value: !Sub "${AWS::StackName}-PrivateAddressApi"
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+  IssueCredentialFunctionCanaryErrors:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      ActionsEnabled: false
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      AlarmDescription: !Sub "Errors returned from the IssueCredentialFunction Lambda."
+      MetricName: Errors
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${AWS::StackName}-IssueCredentialFunction:live"
+        - Name: FunctionName
+          Value: !Ref IssueCredentialFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt IssueCredentialFunction.Version.Version
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Unit: Count
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+
+# Code Deploy Service Role
+
+  CodeDeployServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - codedeploy.amazonaws.com
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda
+      PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
 
 Outputs:
   AddressApiGatewayId:


### PR DESCRIPTION
## Proposed changes

### What changed

- Lambda canary deployment configuration
- Added alarms to Address, IssueCredential, GetAddresses and PostcodeLook up functions.
- Metricerrors alarm and 5xx errors for all but IssueCredential as that does not use APIGW, therefore only Metricerrors alarm added
- Added Code Deploy service role
- Set LambdaDeploymentPreference to AllAtOnce
- Globally set DeploymentPreference to use LambdaDeploymentPreference and Code Deploy service role
- Associated the alarms to specific lambdas

### Why did it change

Lambda canary deployment required

### Issue tracking
- [IPS-1086](https://govukverify.atlassian.net/browse/IPS-1086)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[IPS-1085]: https://govukverify.atlassian.net/browse/IPS-1085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Canary test in dev:
![image](https://github.com/user-attachments/assets/c30439f9-f6a1-469d-8a35-5831541325b7)


<img width="1014" alt="image" src="https://github.com/user-attachments/assets/00f32c95-251d-45ef-aaaf-f8e2a153528f">


[IPS-1086]: https://govukverify.atlassian.net/browse/IPS-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Rollback tested when alarm is triggered:
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/ba1becb3-4823-44fe-b80e-021b6e3b1529">
