### PR TITLE
IPS-1086-lambda-canary-alarms-enabled

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -802,7 +802,7 @@ Resources:
   PostcodeLookupFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: false
+      ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
@@ -828,7 +828,7 @@ Resources:
   PostcodeLookupFunctionCanary5xxErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: false
+      ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
@@ -856,7 +856,7 @@ Resources:
   AddressFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: false
+      ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
@@ -882,7 +882,7 @@ Resources:
   AddressFunctionCanary5xxErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: false
+      ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
@@ -910,7 +910,7 @@ Resources:
   GetAddressesFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: false
+      ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
@@ -936,7 +936,7 @@ Resources:
   GetAddressesFunctionCanary5xxErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: false
+      ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
@@ -964,7 +964,7 @@ Resources:
   IssueCredentialFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: false
+      ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       OKActions:
@@ -990,7 +990,7 @@ Resources:
   IssueCredentialFunctionCanary5xxErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      ActionsEnabled: false
+      ActionsEnabled: true
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       OKActions:


### PR DESCRIPTION
## Proposed changes

### What changed

Setting ActionsEnabled to true for newly deployed canary alarms. 
Enabling alarms from [this PR](https://github.com/govuk-one-login/ipv-cri-address-api/pull/1053)

### Why did it change

When ActionsEnabled is set to true when first deploying alarms, it creates slack notifications. As we don't want slack notifications in production, alarms have been switched off in the initial deployment and now switched on.

### Issue tracking

- [IPA-1086](https://govukverify.atlassian.net/browse/IPS-1086)

## Checklists

### Environment variables or secrets
- [ ] No environment variables or secrets were added or changed


### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks