### PR TITLE
IPS-1143 address 5xx canary alarm switched off

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -447,7 +447,7 @@ Resources:
       DeploymentPreference:
         Alarms:
           - !Ref AddressFunctionCanaryErrors
-          - !Ref AddressFunctionCanary5xxErrors
+          #- !Ref AddressFunctionCanary5xxErrors
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-address"
@@ -879,33 +879,34 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
-  AddressFunctionCanary5xxErrors:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      ActionsEnabled: true
-      AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
-      AlarmDescription: !Sub "AddressFunction Lambda returning 5xx response."
-      Namespace: AWS/ApiGateway
-      MetricName: 5XXError
-      Dimensions:
-        - Name: ApiName
-          Value: !Sub "${AWS::StackName}-PrivateAddressApi"
-        - Name: Method
-          Value: PUT
-        - Name: Stage
-          Value: !Ref Environment
-        - Name: Resource
-          Value: /address
-      Statistic: Sum
-      Unit: Count
-      Period: 60
-      EvaluationPeriods: 1
-      Threshold: 1
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
+#alarm temporarily disabled to avoid false positives and a rollback during deployment
+  # AddressFunctionCanary5xxErrors:
+  #   Type: AWS::CloudWatch::Alarm
+  #   Properties:
+  #     ActionsEnabled: true
+  #     AlarmActions:
+  #       - !ImportValue platform-alarm-warning-alert-topic
+  #     OKActions:
+  #       - !ImportValue platform-alarm-warning-alert-topic
+  #     AlarmDescription: !Sub "AddressFunction Lambda returning 5xx response."
+  #     Namespace: AWS/ApiGateway
+  #     MetricName: 5XXError
+  #     Dimensions:
+  #       - Name: ApiName
+  #         Value: !Sub "${AWS::StackName}-PrivateAddressApi"
+  #       - Name: Method
+  #         Value: PUT
+  #       - Name: Stage
+  #         Value: !Ref Environment
+  #       - Name: Resource
+  #         Value: /address
+  #     Statistic: Sum
+  #     Unit: Count
+  #     Period: 60
+  #     EvaluationPeriods: 1
+  #     Threshold: 1
+  #     ComparisonOperator: GreaterThanOrEqualToThreshold
+  #     TreatMissingData: notBreaching
 
   GetAddressesFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## Proposed changes

### What changed

AddressFunctionCanary5xxErrors removed from deployment strategy for canaries.
AddressFunctionCanary5xxErrors removed altogether. 

### Why did it change

AddressFunctionCanary5xxErrors alarm is firing off frequently. This is being investigated under [OJ-2821](https://govukverify.atlassian.net/browse/OJ-2821).
For the time being, turning this alarm off so that it doesn't cause a false positive during a deployment and cause a rollback. 

### Issue tracking

- [IPS-1143](https://govukverify.atlassian.net/browse/IPS-1143)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-2821]: https://govukverify.atlassian.net/browse/OJ-2821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IPS-1143]: https://govukverify.atlassian.net/browse/IPS-1143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ