### PR TITLE
Add groups to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,15 @@ updates:
         versions: ["17.x","18.x"]
     commit-message:
       prefix: BAU
+    groups:
+      aws:
+        patterns:
+          - "@aws-*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
## Proposed changes

### What changed

Add groups to dependabot following pattern from [core](https://github.com/govuk-one-login/ipv-core-back/blob/main/.github/dependabot.yml).

I am going to test this with address API and roll out to other repos once we're confident that it works for us

### Why did it change

Some groups of dependencies (`@aws-sdk` and `eslint`) should be kept in alignment to prevent compatibility issues between them. This PR ensures that dependabot keeps the alignment
