### PR TITLE
IPS-1158 conditionally deploying canary alarms

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -53,6 +53,7 @@ Conditions:
   IsDevEnvironment: !Equals [!Ref Environment, dev]
   IsProdEnvironment: !Equals [!Ref Environment, production]
   IsNotDevEnvironment: !Not [!Condition IsDevEnvironment]
+  UseCanaryDeploymentAlarms: !Not [ !Equals [ !Ref LambdaDeploymentPreference, AllAtOnce ]]
   UseSecretPrefix: !Not [!Equals [!Ref SecretPrefix, "none"]]
   AddProvisionedConcurrency: !Not
     - !Equals
@@ -372,9 +373,10 @@ Resources:
       CodeUri: ../../lambdas/postcode-lookup
       Handler: uk.gov.di.ipv.cri.address.api.handler.PostcodeLookupHandler::handleRequest
       DeploymentPreference:
-        Alarms:
-          - !Ref PostcodeLookupFunctionCanaryErrors
-          - !Ref PostcodeLookupFunctionCanary5xxErrors
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref PostcodeLookupFunctionCanaryErrors, !Ref PostcodeLookupFunctionCanary5xxErrors]
+          - [!Ref AWS::NoValue]
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-postcode-lookup"
@@ -445,8 +447,10 @@ Resources:
       CodeUri: ../../lambdas/address
       Handler: uk.gov.di.ipv.cri.address.api.handler.AddressHandler::handleRequest
       DeploymentPreference:
-        Alarms:
-          - !Ref AddressFunctionCanaryErrors
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref AddressFunctionCanaryErrors]
+          - [!Ref AWS::NoValue]
           #- !Ref AddressFunctionCanary5xxErrors
       Environment:
         Variables:
@@ -493,9 +497,10 @@ Resources:
     Properties:
       Handler: uk.gov.di.ipv.cri.address.api.handler.IssueCredentialHandler::handleRequest
       DeploymentPreference:
-        Alarms:
-          - !Ref IssueCredentialFunctionCanaryErrors
-          - !Ref IssueCredentialFunctionCanary5xxErrors
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref IssueCredentialFunctionCanaryErrors, !Ref IssueCredentialFunctionCanary5xxErrors]
+          - [!Ref AWS::NoValue]
       CodeUri: ../../lambdas/issuecredential
       Environment:
         Variables:
@@ -556,9 +561,10 @@ Resources:
     Properties:
       Handler: app.lambdaHandler
       DeploymentPreference:
-        Alarms:
-          - !Ref GetAddressesFunctionCanaryErrors
-          - !Ref GetAddressesFunctionCanary5xxErrors
+        Alarms: !If
+          - UseCanaryDeploymentAlarms
+          - [!Ref GetAddressesFunctionCanaryErrors, !Ref GetAddressesFunctionCanary5xxErrors]
+          - [!Ref AWS::NoValue]
       CodeUri: ../../lambdas/get-addresses/
       Runtime: nodejs18.x
       Environment:
@@ -801,6 +807,7 @@ Resources:
 
   PostcodeLookupFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -827,6 +834,7 @@ Resources:
 
   PostcodeLookupFunctionCanary5xxErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -855,6 +863,7 @@ Resources:
 
   AddressFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -882,6 +891,7 @@ Resources:
 #alarm temporarily disabled to avoid false positives and a rollback during deployment
   # AddressFunctionCanary5xxErrors:
   #   Type: AWS::CloudWatch::Alarm
+  #   Condition: UseCanaryDeploymentAlarms
   #   Properties:
   #     ActionsEnabled: true
   #     AlarmActions:
@@ -910,6 +920,7 @@ Resources:
 
   GetAddressesFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -936,6 +947,7 @@ Resources:
 
   GetAddressesFunctionCanary5xxErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -964,6 +976,7 @@ Resources:
 
   IssueCredentialFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -990,6 +1003,7 @@ Resources:
 
   IssueCredentialFunctionCanary5xxErrors:
     Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
     Properties:
       ActionsEnabled: true
       AlarmActions:


### PR DESCRIPTION
## Proposed changes

### What changed

Added a conditional to deploy canary alarms and use canary alarms during deployment only if the deployment strategy is set to all at once.

### Why did it change

This stops alarms being triggered in lower envs where canary is not used and when deploying dev or when a PR is raised.

### Issue tracking

- [IPS-1158](https://govukverify.atlassian.net/browse/IPS-1158)

## Checklists

### Screenshot

- Canary alarms no longer created if deployment preference is AllAtOnce
<img width="521" alt="image" src="https://github.com/user-attachments/assets/154973dc-1bbb-4722-a021-be52156941af">


### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[IPS-1158]: https://govukverify.atlassian.net/browse/IPS-1158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ