### PR TITLE
OJ-2813: address v2 code

### DIFF
--- a/lambdas/get-addresses/src/lib/error-handler.ts
+++ b/lambdas/get-addresses/src/lib/error-handler.ts
@@ -1,0 +1,26 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { APIGatewayProxyResult } from "aws-lambda";
+
+export const handleError = (logger: Logger, error: unknown, functionName: string): APIGatewayProxyResult => {
+    let statusCode = 500;
+    let body = "Internal Server Error";
+
+    if (error instanceof Error) {
+        const { message, stack } = error;
+        body = (error as unknown as APIGatewayProxyResult).body || message;
+        statusCode = (error as unknown as APIGatewayProxyResult).statusCode || 500;
+        logger.error(`Error in ${functionName}: ${message}`, { stack });
+    } else if (typeof error === "object" && error !== null) {
+        const apiError = error as APIGatewayProxyResult;
+        statusCode = apiError.statusCode || 500;
+        body = apiError.body || body;
+        logger.error(`Error in ${functionName}: ${JSON.stringify(body)}`);
+    } else {
+        logger.error(`Unknown error in ${functionName}: ${String(error)}`);
+    }
+
+    return {
+        statusCode,
+        body: JSON.stringify({ message: body }),
+    };
+};

--- a/lambdas/get-addresses/src/lib/session-header.ts
+++ b/lambdas/get-addresses/src/lib/session-header.ts
@@ -1,0 +1,13 @@
+import { APIGatewayProxyEventHeaders, APIGatewayProxyResult } from "aws-lambda";
+
+export const getSessionId = (headers: APIGatewayProxyEventHeaders) => {
+    const sessionId = headers["session_id"];
+    if (!sessionId) {
+        const error = new Error("Missing header: session_id is required");
+        (error as unknown as APIGatewayProxyResult).statusCode = 400;
+        (error as unknown as APIGatewayProxyResult).body = "Missing header: session_id is required";
+
+        throw error;
+    }
+    return sessionId;
+};

--- a/lambdas/get-addresses/src/services/address-service.ts
+++ b/lambdas/get-addresses/src/services/address-service.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { DynamoDBDocument, GetCommand } from "@aws-sdk/lib-dynamodb";
-import { CanonicalAddress } from "../types/address";
+import { CanonicalAddress } from "../types/canonical-address";
 
 export class AddressService {
     constructor(

--- a/lambdas/get-addresses/src/services/dynamodb-service.ts
+++ b/lambdas/get-addresses/src/services/dynamodb-service.ts
@@ -1,0 +1,34 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { DynamoDBDocument, GetCommand } from "@aws-sdk/lib-dynamodb";
+
+export class DynamoDbService {
+    constructor(
+        private readonly dynamoDbClient: DynamoDBDocument,
+        private readonly logger: Logger,
+    ) {}
+
+    public async getItem(sessionId: string, tableName: string): Promise<unknown> {
+        try {
+            const params = new GetCommand({
+                TableName: tableName,
+                Key: {
+                    sessionId: sessionId,
+                },
+            });
+            const result = await this.dynamoDbClient.send(params);
+
+            if (!result.Item) {
+                this.logger.warn(`Could not find ${tableName} item with id: ${sessionId}`);
+            }
+            return result.Item;
+        } catch (error: unknown) {
+            this.logger.error(`Error fetching item from ${tableName} for sessionId: ${sessionId}`, error as Error);
+
+            throw new Error(`Error retrieving ${tableName} item with sessionId: ${sessionId}, due to ${error}`);
+        }
+    }
+
+    public getLogger(): Logger {
+        return this.logger;
+    }
+}

--- a/lambdas/get-addresses/src/types/address.ts
+++ b/lambdas/get-addresses/src/types/address.ts
@@ -1,17 +1,6 @@
-export type CanonicalAddress = {
-    validFrom?: string;
-    validUntil?: string;
-    uprn?: string;
-    organisationName?: string;
-    departmentName?: string;
-    subBuildingName?: string;
-    buildingName?: string;
-    buildingNumber?: string;
-    dependentStreetName?: string;
-    streetName?: string;
-    doubleDependentAddressLocality?: string;
-    dependentAddressLocality?: string;
-    addressLocality?: string;
-    postalCode?: string;
-    addressCountry?: string;
+import { CanonicalAddress } from "./canonical-address";
+
+export type Address = {
+    addresses: CanonicalAddress[];
+    context?: string;
 };

--- a/lambdas/get-addresses/src/types/canonical-address.ts
+++ b/lambdas/get-addresses/src/types/canonical-address.ts
@@ -1,0 +1,17 @@
+export type CanonicalAddress = {
+    validFrom?: string;
+    validUntil?: string;
+    uprn?: string;
+    organisationName?: string;
+    departmentName?: string;
+    subBuildingName?: string;
+    buildingName?: string;
+    buildingNumber?: string;
+    dependentStreetName?: string;
+    streetName?: string;
+    doubleDependentAddressLocality?: string;
+    dependentAddressLocality?: string;
+    addressLocality?: string;
+    postalCode?: string;
+    addressCountry?: string;
+};

--- a/lambdas/get-addresses/src/types/session.ts
+++ b/lambdas/get-addresses/src/types/session.ts
@@ -1,0 +1,12 @@
+export type SessionItem = {
+    expiryDate: number;
+    sessionId: string;
+    clientId: string;
+    clientSessionId: string;
+    authorizationCode?: string;
+    authorizationCodeExpiryDate: number;
+    redirectUri: string;
+    accessToken: string;
+    context?: string;
+    accessTokenExpiryDate: number;
+};

--- a/lambdas/get-addresses/src/v2/get-addresses-v2-handler.ts
+++ b/lambdas/get-addresses/src/v2/get-addresses-v2-handler.ts
@@ -1,0 +1,28 @@
+import type { LambdaInterface } from "@aws-lambda-powertools/commons/types";
+import { Logger } from "@aws-lambda-powertools/logger";
+import { DynamoDbClient } from "../lib/dynamo-db-client";
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda";
+import { handleError } from "../lib/error-handler";
+import { getSessionId } from "../lib/session-header";
+import { AddressServiceV2 } from "./services/address-service-v2";
+
+const logger = new Logger();
+export class AddressesV2Handler implements LambdaInterface {
+    public constructor(private readonly addressService: AddressServiceV2) {}
+
+    public async handler(event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult | undefined> {
+        try {
+            const sessionId = getSessionId(event.headers);
+
+            const result = await this.addressService.getAddressesBySessionId(sessionId);
+
+            return Promise.resolve({ statusCode: 200, body: JSON.stringify({ result }) });
+        } catch (error: unknown) {
+            return handleError(logger, error, context.functionName);
+        }
+    }
+}
+
+const addressService = new AddressServiceV2(DynamoDbClient, logger);
+const handlerClass = new AddressesV2Handler(addressService);
+export const lambdaHandler = handlerClass.handler.bind(handlerClass);

--- a/lambdas/get-addresses/src/v2/services/address-service-v2.ts
+++ b/lambdas/get-addresses/src/v2/services/address-service-v2.ts
@@ -1,0 +1,39 @@
+import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
+import { DynamoDbService } from "../../services/dynamodb-service";
+import { Logger } from "@aws-lambda-powertools/logger";
+import { getParameter } from "@aws-lambda-powertools/parameters/ssm";
+import { Address } from "../../types/address";
+import { CanonicalAddress } from "../../types/canonical-address";
+import { SessionItem } from "../../types/session";
+
+const parameterPrefix = process.env.AWS_STACK_NAME || "";
+const commonParameterPrefix = process.env.COMMON_PARAMETER_NAME_PREFIX || "";
+export class AddressServiceV2 {
+    private readonly dbService: DynamoDbService;
+    constructor(dynamoDbClient: DynamoDBDocument, logger: Logger) {
+        this.dbService = new DynamoDbService(dynamoDbClient, logger);
+    }
+
+    public async getAddressesBySessionId(sessionId: string): Promise<Address> {
+        try {
+            const [addressLookupTableName, sessionTableName] = await Promise.all([
+                getParameter(`/${parameterPrefix}/AddressLookupTableName`),
+                getParameter(`/${commonParameterPrefix}/SessionTableName`),
+            ]);
+
+            const sessionItem = (await this.dbService.getItem(sessionId, sessionTableName as string)) as SessionItem;
+            const items = await this.dbService.getItem(sessionId, addressLookupTableName as string);
+            const canonicalAddresses = items ? (items as CanonicalAddress[]) : [];
+
+            return {
+                ...(sessionItem?.context && { context: sessionItem?.context }),
+                addresses: canonicalAddresses,
+            };
+        } catch (error: unknown) {
+            this.dbService
+                .getLogger()
+                .error(`Failed to retrieve addresses for session ID: ${sessionId}`, error as Error);
+            throw error;
+        }
+    }
+}

--- a/lambdas/get-addresses/tests/unit/app.test.ts
+++ b/lambdas/get-addresses/tests/unit/app.test.ts
@@ -1,8 +1,8 @@
 import { getParameter } from "@aws-lambda-powertools/parameters/ssm";
 import { APIGatewayProxyEvent } from "aws-lambda";
 import { lambdaHandler } from "../../src/app";
-import { CanonicalAddress } from "../../src/types/address";
 import { DynamoDbClient } from "../../src/lib/dynamo-db-client";
+import { CanonicalAddress } from "../../src/types/canonical-address";
 
 jest.mock("@aws-lambda-powertools/parameters/ssm", () => ({
     getParameter: jest.fn(),

--- a/lambdas/get-addresses/tests/unit/get-addresses-v2-handler.test.ts
+++ b/lambdas/get-addresses/tests/unit/get-addresses-v2-handler.test.ts
@@ -1,0 +1,201 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { AddressesV2Handler } from "../../src/v2/get-addresses-v2-handler";
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda";
+import { DynamoDbClient } from "../../src/lib/dynamo-db-client";
+import { AddressServiceV2 } from "../../src/v2/services/address-service-v2";
+jest.mock("@aws-lambda-powertools/logger");
+jest.mock("../../src/v2/services/address-service-v2");
+const logger = new Logger();
+const mockedLogger = jest.mocked(Logger);
+const dynamoDbClientMock = jest.mocked(DynamoDbClient);
+const addressService = new AddressServiceV2(dynamoDbClientMock, logger);
+const mockContext: Partial<Context> = {
+    functionName: "testFunction",
+};
+
+describe("get-addresses-v2-handler", () => {
+    let loggerSpy: jest.SpyInstance<unknown, never, unknown>;
+    const handlerClass = new AddressesV2Handler(addressService);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        loggerSpy = jest.spyOn(mockedLogger.prototype, "error");
+    });
+
+    it("returns 400 when session_id header is missing", async () => {
+        const result = await handlerClass.handler(
+            {
+                headers: {},
+            } as APIGatewayProxyEvent,
+            mockContext as Context,
+        );
+
+        expect(result).toEqual({
+            body: JSON.stringify({ message: "Missing header: session_id is required" }),
+            statusCode: 400,
+        });
+    });
+
+    it("handles standard Error thrown by service and returns status code 500", async () => {
+        const params: Partial<APIGatewayProxyEvent> = {
+            headers: {
+                session_id: "123-abc",
+            },
+        };
+        const dynamoError = new Error("DynamoDB Error");
+
+        jest.spyOn(addressService, "getAddressesBySessionId").mockRejectedValueOnce(dynamoError);
+        const response = await handlerClass.handler(params as APIGatewayProxyEvent, mockContext as Context);
+
+        expect(response).toEqual({
+            statusCode: 500,
+            body: JSON.stringify({ message: "DynamoDB Error" }),
+        });
+        expect(loggerSpy).toHaveBeenCalledWith(`Error in testFunction: ${dynamoError.message}`, {
+            stack: dynamoError.stack,
+        });
+    });
+
+    it("handles non-standard error with custom status code and message", async () => {
+        const params: Partial<APIGatewayProxyEvent> = {
+            headers: {
+                session_id: "123-abc",
+            },
+        };
+
+        const customError: APIGatewayProxyResult = {
+            statusCode: 400,
+            body: "Custom Error Message",
+        };
+        jest.spyOn(addressService, "getAddressesBySessionId").mockRejectedValueOnce(customError);
+
+        const response = await handlerClass.handler(params as APIGatewayProxyEvent, mockContext as Context);
+
+        expect(response).toEqual({
+            statusCode: 400,
+            body: JSON.stringify({ message: "Custom Error Message" }),
+        });
+        expect(loggerSpy).toHaveBeenCalledWith(`Error in testFunction: ${JSON.stringify(customError.body)}`);
+    });
+
+    it("handles an unknown error and returns default 500 Internal Server Error", async () => {
+        const params: Partial<APIGatewayProxyEvent> = {
+            headers: {
+                session_id: "123-abc",
+            },
+        };
+
+        const unknownError = { unknownField: "unknownValue" };
+        jest.spyOn(addressService, "getAddressesBySessionId").mockRejectedValueOnce(unknownError);
+
+        const response = await handlerClass.handler(params as APIGatewayProxyEvent, mockContext as Context);
+
+        expect(response).toEqual({
+            statusCode: 500,
+            body: JSON.stringify({ message: "Internal Server Error" }),
+        });
+        expect(loggerSpy).toHaveBeenCalledWith(`Error in testFunction: ${JSON.stringify("Internal Server Error")}`);
+    });
+    describe("with context", () => {
+        it("returns 200 with context when getAddressesBySessionId resolves successfully", async () => {
+            const mockResult = {
+                context: "new-context",
+                addresses: [
+                    {
+                        streetName: "Downing street",
+                        buildingNumber: "10",
+                        postalCode: "SW1A 2AA",
+                    },
+                ],
+            };
+
+            const mockEvent: Partial<APIGatewayProxyEvent> = {
+                headers: {
+                    session_id: "test-session-id",
+                },
+            };
+
+            jest.spyOn(addressService, "getAddressesBySessionId").mockResolvedValueOnce(mockResult);
+            const response = await handlerClass.handler(mockEvent as APIGatewayProxyEvent, mockContext as Context);
+
+            expect(response).toEqual({
+                statusCode: 200,
+                body: JSON.stringify({ result: mockResult }),
+            });
+            expect(addressService.getAddressesBySessionId).toHaveBeenCalledWith("test-session-id");
+        });
+
+        it("returns 200 with an empty address array when no address is found", async () => {
+            const mockResult = {
+                context: "new-context",
+                addresses: [],
+            };
+
+            const mockEvent: Partial<APIGatewayProxyEvent> = {
+                headers: {
+                    session_id: "test-session-id",
+                },
+            };
+
+            jest.spyOn(addressService, "getAddressesBySessionId").mockResolvedValueOnce(mockResult);
+            const response = await handlerClass.handler(mockEvent as APIGatewayProxyEvent, mockContext as Context);
+
+            expect(response).toEqual({
+                statusCode: 200,
+                body: JSON.stringify({ result: mockResult }),
+            });
+            expect(addressService.getAddressesBySessionId).toHaveBeenCalledWith("test-session-id");
+        });
+    });
+
+    describe("without context", () => {
+        it("returns 200 without context when getAddressesBySessionId resolves successfully", async () => {
+            const mockResult = {
+                addresses: [
+                    {
+                        streetName: "Downing street",
+                        buildingNumber: "10",
+                        postalCode: "SW1A 2AA",
+                    },
+                ],
+            };
+
+            const mockEvent: Partial<APIGatewayProxyEvent> = {
+                headers: {
+                    session_id: "test-session-id",
+                },
+            };
+
+            jest.spyOn(addressService, "getAddressesBySessionId").mockResolvedValueOnce(mockResult);
+            const response = await handlerClass.handler(mockEvent as APIGatewayProxyEvent, mockContext as Context);
+
+            expect(response).toEqual({
+                statusCode: 200,
+                body: JSON.stringify({ result: mockResult }),
+            });
+            expect(addressService.getAddressesBySessionId).toHaveBeenCalledWith("test-session-id");
+        });
+
+        it("returns 200 with an empty address array and no context when no address is found", async () => {
+            const mockResult = {
+                addresses: [],
+            };
+
+            const mockEvent: Partial<APIGatewayProxyEvent> = {
+                headers: {
+                    session_id: "test-session-id",
+                },
+            };
+
+            jest.spyOn(addressService, "getAddressesBySessionId").mockResolvedValueOnce(mockResult);
+            const response = await handlerClass.handler(mockEvent as APIGatewayProxyEvent, mockContext as Context);
+
+            expect(response).toEqual({
+                statusCode: 200,
+                body: JSON.stringify({ result: mockResult }),
+            });
+            expect(addressService.getAddressesBySessionId).toHaveBeenCalledWith("test-session-id");
+        });
+    });
+});

--- a/lambdas/get-addresses/tests/unit/lib/error-handler.test.ts
+++ b/lambdas/get-addresses/tests/unit/lib/error-handler.test.ts
@@ -1,0 +1,89 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { handleError } from "../../../src/lib/error-handler";
+import { APIGatewayProxyResult } from "aws-lambda";
+
+const mockLogger = {
+    error: jest.fn(),
+} as unknown as Logger;
+
+describe("handleError", () => {
+    const functionName = "testFunction";
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("handles Error objects and log the error without statusCode set and default to 500", () => {
+        const mockError = new Error("Test error message");
+
+        const result = handleError(mockLogger, mockError, functionName);
+
+        expect(mockLogger.error).toHaveBeenCalledWith(`Error in ${functionName}: ${mockError.message}`, {
+            stack: mockError.stack,
+        });
+
+        expect(result).toEqual({
+            statusCode: 500,
+            body: JSON.stringify({ message: "Test error message" }),
+        });
+    });
+
+    it("handles Error objects and log the error with statusCode set", () => {
+        const mockError = new Error("Test error message");
+        (mockError as unknown as APIGatewayProxyResult).statusCode = 400;
+        (mockError as unknown as APIGatewayProxyResult).body = "Missing header: session_id is required";
+
+        const result = handleError(mockLogger, mockError, functionName);
+
+        expect(mockLogger.error).toHaveBeenCalledWith(`Error in ${functionName}: ${mockError.message}`, {
+            stack: mockError.stack,
+        });
+
+        expect(result).toEqual({
+            statusCode: 400,
+            body: JSON.stringify({ message: "Missing header: session_id is required" }),
+        });
+    });
+
+    it("handles API Gateway-style error responses and log the error", () => {
+        const apiError: APIGatewayProxyResult = {
+            statusCode: 404,
+            body: "Not Found",
+        };
+
+        const result = handleError(mockLogger, apiError, functionName);
+
+        expect(mockLogger.error).toHaveBeenCalledWith(`Error in ${functionName}: ${JSON.stringify("Not Found")}`);
+
+        expect(result).toEqual({
+            statusCode: 404,
+            body: JSON.stringify({ message: "Not Found" }),
+        });
+    });
+
+    it("handles unknown error types and log a generic error", () => {
+        const unknownError = 12345;
+
+        const result = handleError(mockLogger, unknownError, functionName);
+
+        expect(mockLogger.error).toHaveBeenCalledWith(`Unknown error in ${functionName}: ${String(unknownError)}`);
+
+        expect(result).toEqual({
+            statusCode: 500,
+            body: JSON.stringify({ message: "Internal Server Error" }),
+        });
+    });
+
+    it("handles null or undefined error and log a generic error", () => {
+        const nullError = null;
+
+        const result = handleError(mockLogger, nullError, functionName);
+
+        expect(mockLogger.error).toHaveBeenCalledWith(`Unknown error in ${functionName}: null`);
+
+        expect(result).toEqual({
+            statusCode: 500,
+            body: JSON.stringify({ message: "Internal Server Error" }),
+        });
+    });
+});

--- a/lambdas/get-addresses/tests/unit/services/address-service-v2.test.ts
+++ b/lambdas/get-addresses/tests/unit/services/address-service-v2.test.ts
@@ -1,0 +1,147 @@
+jest.mock("@aws-sdk/lib-dynamodb", () => {
+    const originalModule = jest.requireActual("@aws-sdk/lib-dynamodb");
+    return {
+        __esModule: true,
+        ...originalModule,
+        GetCommand: jest.fn(),
+    };
+});
+jest.mock("@aws-lambda-powertools/parameters/ssm", () => ({
+    getParameter: jest.fn(),
+}));
+
+import { getParameter } from "@aws-lambda-powertools/parameters/ssm";
+import { DynamoDbClient } from "../../../src/lib/dynamo-db-client";
+import { Logger } from "@aws-lambda-powertools/logger";
+import { CanonicalAddress } from "../../../src/types/canonical-address";
+import { AddressServiceV2 } from "../../../src/v2/services/address-service-v2";
+import { GetCommand } from "@aws-sdk/lib-dynamodb";
+const mockDynamoDbClient = jest.mocked(DynamoDbClient);
+const mockLogger = jest.mocked(Logger);
+const mockGetCommand = jest.mocked(GetCommand);
+const getParameterMock = jest.mocked(getParameter);
+
+describe("Address Service V2 Test", () => {
+    let addressService: AddressServiceV2;
+    const addressTableName = "ADDRESS_TABLE";
+    const sessionTable = "SESSION_TABLE";
+    const sessionId = "SESSION_ID";
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        getParameterMock.mockResolvedValueOnce(addressTableName);
+        getParameterMock.mockResolvedValueOnce(sessionTable);
+
+        addressService = new AddressServiceV2(DynamoDbClient, mockLogger.prototype);
+    });
+
+    const testCases = [
+        {
+            description: "with context",
+            sessionItem: { context: "new-context" },
+            expectedResult: (addresses: CanonicalAddress[]) => ({
+                context: "new-context",
+                addresses,
+            }),
+        },
+        {
+            description: "without context",
+            sessionItem: undefined,
+            expectedResult: (addresses: CanonicalAddress[]) => ({
+                addresses,
+            }),
+        },
+    ];
+
+    testCases.forEach(({ description, sessionItem, expectedResult }) => {
+        describe(description, () => {
+            it("returns an address when passed a session Id", async () => {
+                const addresses: CanonicalAddress[] = [
+                    {
+                        streetName: "Downing street",
+                        buildingNumber: "10",
+                        postalCode: "SW1A 2AA",
+                    },
+                ];
+
+                mockDynamoDbClient.send = jest
+                    .fn()
+                    .mockResolvedValueOnce({ Item: sessionItem })
+                    .mockResolvedValueOnce({ Item: addresses });
+
+                const result = await addressService.getAddressesBySessionId(sessionId);
+                expect(mockGetCommand).toHaveBeenNthCalledWith(1, {
+                    TableName: sessionTable,
+                    Key: {
+                        sessionId,
+                    },
+                });
+                expect(mockGetCommand).toHaveBeenNthCalledWith(2, {
+                    TableName: addressTableName,
+                    Key: {
+                        sessionId,
+                    },
+                });
+
+                expect(result).not.toBeNull();
+                expect(result).toEqual(expectedResult(addresses));
+            });
+
+            it("returns an empty array when no address is found", async () => {
+                mockDynamoDbClient.send = jest
+                    .fn()
+                    .mockResolvedValueOnce({ Item: sessionItem })
+                    .mockResolvedValueOnce({ Item: undefined });
+
+                const result = await addressService.getAddressesBySessionId(sessionId);
+
+                expect(mockGetCommand).toHaveBeenNthCalledWith(1, {
+                    TableName: sessionTable,
+                    Key: {
+                        sessionId,
+                    },
+                });
+                expect(mockGetCommand).toHaveBeenNthCalledWith(2, {
+                    TableName: addressTableName,
+                    Key: {
+                        sessionId,
+                    },
+                });
+
+                expect(result).not.toBeNull();
+                expect(result).toEqual(expectedResult([]));
+            });
+
+            it("returns an error when dynamoDB throws an error", async () => {
+                try {
+                    expect.assertions(5);
+                    mockDynamoDbClient.send = jest
+                        .fn()
+                        .mockResolvedValueOnce({ Item: sessionItem })
+                        .mockRejectedValueOnce(new Error("DynamoDB Error"));
+
+                    await addressService.getAddressesBySessionId(sessionId);
+                } catch (err) {
+                    expect(mockGetCommand).toHaveBeenNthCalledWith(1, {
+                        TableName: sessionTable,
+                        Key: {
+                            sessionId,
+                        },
+                    });
+                    expect(mockGetCommand).toHaveBeenNthCalledWith(2, {
+                        TableName: addressTableName,
+                        Key: {
+                            sessionId,
+                        },
+                    });
+
+                    expect(err).toBeDefined();
+                    expect(typeof err).toBe("object");
+
+                    const errorObj = err as Error;
+                    expect(errorObj.message).toContain("DynamoDB Error");
+                }
+            });
+        });
+    });
+});

--- a/lambdas/get-addresses/tests/unit/services/address-service.test.ts
+++ b/lambdas/get-addresses/tests/unit/services/address-service.test.ts
@@ -6,22 +6,29 @@ jest.mock("@aws-sdk/lib-dynamodb", () => {
         GetCommand: jest.fn(),
     };
 });
+jest.mock("@aws-lambda-powertools/parameters/ssm", () => ({
+    getParameter: jest.fn(),
+}));
 
+import { getParameter } from "@aws-lambda-powertools/parameters/ssm";
+import { CanonicalAddress } from "../../../src/types/canonical-address";
 import { AddressService } from "../../../src/services/address-service";
-import { DynamoDbClient } from "../../../src/lib/dynamo-db-client";
 import { GetCommand } from "@aws-sdk/lib-dynamodb";
-import { CanonicalAddress } from "../../../src/types/address";
+import { DynamoDbClient } from "../../../src/lib/dynamo-db-client";
 
 const mockDynamoDbClient = jest.mocked(DynamoDbClient);
 const mockGetCommand = jest.mocked(GetCommand);
+const getParameterMock = jest.mocked(getParameter);
 
 describe("Address Service", () => {
     let addressService: AddressService;
-    const tableName = "MYTABLE";
-    const sessionId = "SESSID";
+    const tableName = "MY_TABLE";
+    const sessionId = "SESSION_ID";
 
     beforeEach(() => {
         jest.resetAllMocks();
+        getParameterMock.mockResolvedValue(tableName);
+
         addressService = new AddressService(tableName, DynamoDbClient);
     });
 

--- a/lambdas/get-addresses/tests/unit/services/dynamodb-service.test.ts
+++ b/lambdas/get-addresses/tests/unit/services/dynamodb-service.test.ts
@@ -1,0 +1,72 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { DynamoDbService } from "../../../src/services/dynamodb-service";
+import { DynamoDBDocument } from "@aws-sdk/lib-dynamodb";
+
+const mockDynamoDbClient = {
+    send: jest.fn(),
+};
+const mockLogger = {
+    error: jest.fn(),
+    warn: jest.fn(),
+} as unknown as Logger;
+
+describe("DynamoDbService", () => {
+    let dynamoDbService: DynamoDbService;
+
+    beforeEach(() => {
+        dynamoDbService = new DynamoDbService(mockDynamoDbClient as unknown as DynamoDBDocument, mockLogger);
+        jest.clearAllMocks();
+    });
+
+    const sessionId = "session-id";
+    const tableName = "test-table";
+
+    it("returns the logger instance", () => {
+        const logger = dynamoDbService.getLogger();
+
+        expect(logger).toBe(mockLogger);
+    });
+
+    it("returns the item when found", async () => {
+        const mockItem = { sessionId: "test-session-id", data: "some data" };
+        mockDynamoDbClient.send.mockResolvedValueOnce({ Item: mockItem });
+
+        const result = await dynamoDbService.getItem(sessionId, tableName);
+
+        expect(mockDynamoDbClient.send).toHaveBeenCalledWith(
+            expect.objectContaining({
+                input: {
+                    TableName: tableName,
+                    Key: { sessionId: sessionId },
+                },
+            }),
+        );
+
+        expect(mockLogger.warn).not.toHaveBeenCalled();
+        expect(result).toEqual(mockItem);
+    });
+
+    it("logs a warning when no item is found", async () => {
+        mockDynamoDbClient.send.mockResolvedValueOnce({ Item: undefined });
+
+        const result = await dynamoDbService.getItem(sessionId, tableName);
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(`Could not find ${tableName} item with id: ${sessionId}`);
+
+        expect(result).toBeUndefined();
+    });
+
+    it("logs an error and throw when DynamoDB throws an error", async () => {
+        const mockError = new Error("DynamoDB Error");
+        mockDynamoDbClient.send.mockRejectedValueOnce(mockError);
+
+        await expect(dynamoDbService.getItem(sessionId, tableName)).rejects.toThrow(
+            `Error retrieving ${tableName} item with sessionId: ${sessionId}, due to ${mockError}`,
+        );
+
+        expect(mockLogger.error).toHaveBeenCalledWith(
+            `Error fetching item from ${tableName} for sessionId: ${sessionId}`,
+            mockError,
+        );
+    });
+});


### PR DESCRIPTION
## Proposed changes

Implement V2 code changes, that will be used to generate the expected structure for the `/addresses/v2` endpoint
Subsequent PR's will connect this up with `/addresses/v2` endpoint

Once merged, am going to continue on the work [here](https://github.com/govuk-one-login/ipv-cri-address-api/pull/1080)

```
{
  addresses: [
    {
      validFrom?: string;
      validUntil?: string;
      uprn?: string;
      organisationName?: string;
      departmentName?: string;
      subBuildingName?: string;
      buildingName?: string;
      buildingNumber?: string;
      dependentStreetName?: string;
      streetName?: string;
      doubleDependentAddressLocality?: string;
      dependentAddressLocality?: string;
      addressLocality?: string;
      postalCode?: string;
      addressCountry?: string;
    }
  ], // empty array if no addresses
  context?: string;
}
```

### What changed

When receiving a context claim in the JAR when a user starts Address CRI.  A new version of the API is needed that would be released to also return the context. separate from the current which doesn't this will leave side by side for a while

### Why did it change

We receive a context claim in the JAR when a user starts Address CRI. We need a way for the fronted to receive this claim so that it can route them to the correct page. We already make an API call to fetch shared_claims that come from this JAR

### Issue tracking
>

- [OJ-2813](https://govukverify.atlassian.net/browse/OJ-2813)


[OJ-2813]: https://govukverify.atlassian.net/browse/OJ-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ