### PR TITLE
OJ-2810: Add ttl to Address Table

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -672,6 +672,9 @@ Resources:
       KeySchema:
         - AttributeName: "sessionId"
           KeyType: "HASH"
+      TimeToLiveSpecification:
+        AttributeName: expiryDate
+        Enabled: true
 
   PublicAddressApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan

--- a/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
+++ b/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
@@ -44,6 +44,7 @@ public class AddressHandler
     private final AddressService addressService;
     private final SessionService sessionService;
     private final EventProbe eventProbe;
+    private final long addressTtl;
 
     @ExcludeFromGeneratedCoverageReport
     public AddressHandler() {
@@ -65,6 +66,8 @@ public class AddressHandler
                         clientProviderFactory.getSSMProvider(),
                         clientProviderFactory.getSecretsProvider());
 
+        addressTtl = configurationService.getSessionExpirationEpoch();
+
         this.sessionService =
                 new SessionService(
                         configurationService, clientProviderFactory.getDynamoDbEnhancedClient());
@@ -73,10 +76,14 @@ public class AddressHandler
     }
 
     public AddressHandler(
-            SessionService sessionService, AddressService addressService, EventProbe eventProbe) {
+            SessionService sessionService,
+            AddressService addressService,
+            EventProbe eventProbe,
+            long addressTtl) {
         this.sessionService = sessionService;
         this.addressService = addressService;
         this.eventProbe = eventProbe;
+        this.addressTtl = addressTtl;
     }
 
     @Override
@@ -99,7 +106,7 @@ public class AddressHandler
                 addressService.setAddressValidity(addresses);
 
                 // Save our addresses to the address table
-                addressService.saveAddresses(UUID.fromString(sessionId), addresses);
+                addressService.saveAddresses(UUID.fromString(sessionId), addresses, addressTtl);
 
                 // Now we've saved our address, we need to create an authorization code for the
                 // session

--- a/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
+++ b/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
@@ -39,6 +39,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class AddressHandlerTest {
     private static final String SESSION_ID = UUID.randomUUID().toString();
+    private static final long ADDRESS_TTL = 1730197212;
+
     @Mock private SessionService mockSessionService;
     @Mock private AddressService mockAddressService;
 
@@ -50,7 +52,8 @@ class AddressHandlerTest {
 
     @BeforeEach
     void setUp() {
-        addressHandler = new AddressHandler(mockSessionService, mockAddressService, eventProbe);
+        addressHandler =
+                new AddressHandler(mockSessionService, mockAddressService, eventProbe, ADDRESS_TTL);
     }
 
     @Test
@@ -96,10 +99,12 @@ class AddressHandlerTest {
 
         AddressItem addressItem = new AddressItem();
         addressItem.setAddresses(canonicalAddresses);
+        addressItem.setExpiryDate(ADDRESS_TTL);
 
         when(mockSessionService.validateSessionId(SESSION_ID)).thenReturn(sessionItem);
         when(mockAddressService.parseAddresses(anyString())).thenReturn(canonicalAddresses);
-        when(mockAddressService.saveAddresses(notNull(), anyList())).thenReturn(addressItem);
+        when(mockAddressService.saveAddresses(notNull(), anyList(), eq(ADDRESS_TTL)))
+                .thenReturn(addressItem);
 
         APIGatewayProxyResponseEvent responseEvent =
                 addressHandler.handleRequest(apiGatewayProxyRequestEvent, null);

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/item/AddressItem.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/persistence/item/AddressItem.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 @DynamoDbBean
 public class AddressItem {
     private UUID sessionId;
+    private long expiryDate;
     private List<CanonicalAddress> addresses = new ArrayList<>();
 
     @DynamoDbPartitionKey()
@@ -21,6 +22,14 @@ public class AddressItem {
 
     public void setSessionId(UUID sessionId) {
         this.sessionId = sessionId;
+    }
+
+    public long getExpiryDate() {
+        return expiryDate;
+    }
+
+    public void setExpiryDate(long expiryDate) {
+        this.expiryDate = expiryDate;
     }
 
     public List<CanonicalAddress> getAddresses() {

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 
 public class AddressService {
     private static final Logger LOGGER = LogManager.getLogger();
+
     private static final String ERROR_SINGLE_ADDRESS_NOT_CURRENT =
             "setAddressValidity found a single address but is not a CURRENT address.";
     private static final String ERROR_TOO_MANY_ADDRESSES =
@@ -35,6 +36,7 @@ public class AddressService {
 
     private final DataStore<AddressItem> dataStore;
     private final ObjectMapper objectMapper;
+
     private ObjectReader addressReader;
 
     @ExcludeFromGeneratedCoverageReport
@@ -67,10 +69,11 @@ public class AddressService {
         return addresses;
     }
 
-    public AddressItem saveAddresses(UUID sessionId, List<CanonicalAddress> addresses) {
+    public AddressItem saveAddresses(
+            UUID sessionId, List<CanonicalAddress> addresses, long ttlExpiryEpoch) {
         AddressItem addressItem = new AddressItem();
-
         addressItem.setSessionId(sessionId);
+        addressItem.setExpiryDate(ttlExpiryEpoch);
         addressItem.setAddresses(addresses);
         dataStore.create(addressItem);
 

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
@@ -53,6 +53,8 @@ class AddressServiceTest {
             "setAddressValidity found address where validFrom and validUntil are Equal.";
     private static final String ERROR_COUNTRY_CODE_NOT_PRESENT =
             "Country code not present for address";
+    private static final long ADDRESS_TTL = 1730197212;
+
     private ObjectMapper objectMapper;
 
     @BeforeEach
@@ -276,7 +278,7 @@ class AddressServiceTest {
             addresses.add(address2);
             addresses.add(address3);
 
-            addressService.saveAddresses(SESSION_ID, addresses);
+            addressService.saveAddresses(SESSION_ID, addresses, ADDRESS_TTL);
             ArgumentCaptor<AddressItem> addressItemArgumentCaptor =
                     ArgumentCaptor.forClass(AddressItem.class);
             verify(mockDataStore).create(addressItemArgumentCaptor.capture());
@@ -284,11 +286,13 @@ class AddressServiceTest {
                     addressItemArgumentCaptor.getValue().getAddresses(), equalTo(addresses));
             MatcherAssert.assertThat(
                     addressItemArgumentCaptor.getValue().getSessionId(), equalTo(SESSION_ID));
+            MatcherAssert.assertThat(
+                    addressItemArgumentCaptor.getValue().getExpiryDate(), equalTo(ADDRESS_TTL));
         }
 
         @Test
         void shouldPersistAnEmptyListOfAddressesWhenNoListOfCanonicalAddressesIsSupplied() {
-            addressService.saveAddresses(SESSION_ID, null);
+            addressService.saveAddresses(SESSION_ID, null, ADDRESS_TTL);
             ArgumentCaptor<AddressItem> addressItemArgumentCaptor =
                     ArgumentCaptor.forClass(AddressItem.class);
             verify(mockDataStore).create(addressItemArgumentCaptor.capture());
@@ -297,6 +301,8 @@ class AddressServiceTest {
                     equalTo(new ArrayList<>()));
             MatcherAssert.assertThat(
                     addressItemArgumentCaptor.getValue().getSessionId(), equalTo(SESSION_ID));
+            MatcherAssert.assertThat(
+                    addressItemArgumentCaptor.getValue().getExpiryDate(), equalTo(ADDRESS_TTL));
         }
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed

Added expiryDate to AddressItem and set as TTL
Use the SessionTtl for the AddressTtl as these values should be the same. 

### Why did it change

We should only keep data for as long as we need it (especially as it’s PII). Without a TTL to remove it after some time means that we’ll be accumulating unnecessary costs and also eventually breach GDPR.

### Issue tracking

- [OJ-2810](https://govukverify.atlassian.net/browse/OJ-2810)

## Checklists

### Evidence

![image](https://github.com/user-attachments/assets/beddadb4-f1a9-4226-9819-d101533d0fdd)

[OJ-2810]: https://govukverify.atlassian.net/browse/OJ-2810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ