### PR TITLE
OJ-2816: Add addressRegion to CanonicalAddress

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "3.1.2",
+		cri_common_lib           : "3.2.1",
 		pact_provider_version	 : "4.5.11",
 		webcompere_version       : "2.1.6",
 		slf4j_log4j12_version    : "2.0.13", // For contract test debug

--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -396,6 +396,10 @@ components:
           type: "string"
           example: "GB"
           description: "ISO 2-Letter Country Code"
+        addressRegion:
+          type: "string"
+          example: "IL"
+          description: "The state, district, county, parish or province"
         validFrom:
           description: "Date in ISO 8601 format"
           type: "string"

--- a/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
@@ -46,6 +46,7 @@ public class AddressApiClient {
         currentAddress.setPostalCode(postcode);
         currentAddress.setValidFrom(LocalDate.of(2020, 1, 1));
         currentAddress.setAddressCountry(countryCode);
+        currentAddress.setAddressRegion("DummyRegion");
 
         String requestBody =
                 objectMapper.writeValueAsString(new CanonicalAddress[] {currentAddress});

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -180,6 +180,9 @@ public class AddressSteps {
         assertEquals(postcode, payload.at("/vc/credentialSubject/address/0/postalCode").asText());
         assertEquals(
                 countryCode, payload.at("/vc/credentialSubject/address/0/addressCountry").asText());
+        assertEquals(
+                "DummyRegion",
+                payload.at("/vc/credentialSubject/address/0/addressRegion").asText());
     }
 
     @When("the user arrives at find your address page")

--- a/lambdas/get-addresses/src/types/canonical-address.ts
+++ b/lambdas/get-addresses/src/types/canonical-address.ts
@@ -14,4 +14,5 @@ export type CanonicalAddress = {
     addressLocality?: string;
     postalCode?: string;
     addressCountry?: string;
+    addressRegion?: string;
 };

--- a/lambdas/get-addresses/tests/unit/app.test.ts
+++ b/lambdas/get-addresses/tests/unit/app.test.ts
@@ -26,6 +26,7 @@ describe("Handler", () => {
                     streetName: "Downing street",
                     buildingNumber: "10",
                     postalCode: "SW1A 2AA",
+                    addressRegion: "Greater London Authority",
                 },
             ],
         };

--- a/lambdas/get-addresses/tests/unit/get-addresses-v2-handler.test.ts
+++ b/lambdas/get-addresses/tests/unit/get-addresses-v2-handler.test.ts
@@ -108,6 +108,7 @@ describe("get-addresses-v2-handler", () => {
                         streetName: "Downing street",
                         buildingNumber: "10",
                         postalCode: "SW1A 2AA",
+                        addressRegion: "Greater London Authority",
                     },
                 ],
             };
@@ -159,6 +160,7 @@ describe("get-addresses-v2-handler", () => {
                         streetName: "Downing street",
                         buildingNumber: "10",
                         postalCode: "SW1A 2AA",
+                        addressRegion: "Greater London Authority",
                     },
                 ],
             };

--- a/lambdas/get-addresses/tests/unit/services/address-service-v2.test.ts
+++ b/lambdas/get-addresses/tests/unit/services/address-service-v2.test.ts
@@ -45,6 +45,7 @@ describe("Address Service V2 Test", () => {
                         streetName: "Downing street",
                         buildingNumber: "10",
                         postalCode: "SW1A 2AA",
+                        addressRegion: "Greater London Authority",
                     },
                 ],
             };

--- a/lambdas/get-addresses/tests/unit/services/address-service.test.ts
+++ b/lambdas/get-addresses/tests/unit/services/address-service.test.ts
@@ -40,6 +40,7 @@ describe("Address Service", () => {
                     streetName: "Downing street",
                     buildingNumber: "10",
                     postalCode: "SW1A 2AA",
+                    addressRegion: "Greater London Authority",
                 },
             ],
         };

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
@@ -84,6 +84,7 @@ class AddressServiceTest {
                             + "      \"addressLocality\": \"LEEDS\",\n"
                             + "      \"postalCode\": \"LS10 4QL\",\n"
                             + "      \"addressCountry\": \"GB\",\n"
+                            + "      \"addressRegion\": \"YORKSHIRE\",\n"
                             + "      \"validFrom\": \"2010-02-26\",\n"
                             + "      \"validUntil\": \"2021-01-16\"\n"
                             + "   },\n"
@@ -112,6 +113,7 @@ class AddressServiceTest {
             List<CanonicalAddress> parsedAddresses = addressService.parseAddresses(addresses);
 
             assertThat(parsedAddresses.size(), equalTo(3));
+            assertEquals("YORKSHIRE", parsedAddresses.get(0).getAddressRegion());
         }
 
         @Test
@@ -125,6 +127,7 @@ class AddressServiceTest {
                             + "      \"addressLocality\": \"LEEDS\",\n"
                             + "      \"postalCode\": \"LS10 4QL\",\n"
                             + "      \"addressCountry\": \"GB\",\n"
+                            + "      \"addressRegion\": \"YORKSHIRE\",\n"
                             + "      \"validFrom\": \"2010-00-00\",\n"
                             + "      \"validUntil\": \"2021-01-16\"\n"
                             + "   },\n"
@@ -139,12 +142,13 @@ class AddressServiceTest {
                     addressProcessingException.getMessage(),
                     containsString(
                             String.format(
-                                    "could not parse addresses...Error while deserializing object. Some PII fields were redacted. {\"uprn\":\"%s\",\"buildingNumber\":\"*\",\"streetName\":\"%s\",\"addressLocality\":\"%s\",\"postalCode\":\"%s\",\"addressCountry\":\"%s\",\"validFrom\":\"**********\",\"validUntil\":\"**********\"}",
+                                    "could not parse addresses...Error while deserializing object. Some PII fields were redacted. {\"uprn\":\"%s\",\"buildingNumber\":\"*\",\"streetName\":\"%s\",\"addressLocality\":\"%s\",\"postalCode\":\"%s\",\"addressCountry\":\"%s\",\"addressRegion\":\"%s\",\"validFrom\":\"**********\",\"validUntil\":\"**********\"}",
                                     "*".repeat("72262801".length()),
                                     "*".repeat("GRANGE FIELDS WAY".length()),
                                     "*".repeat("LEEDS".length()),
                                     "*".repeat("LS10 4QL".length()),
                                     "*".repeat("GB".length()),
+                                    "*".repeat("YORKSHIRE".length()),
                                     "*".repeat("2010-00-00".length()),
                                     "*".repeat("2021-01-16".length()))));
         }
@@ -159,6 +163,7 @@ class AddressServiceTest {
                             + "      \"streetName\": \"GRANGE FIELDS WAY\",\n"
                             + "      \"addressLocality\": \"LEEDS\",\n"
                             + "      \"postalCode\": \"LS10 4QL\",\n"
+                            + "      \"addressRegion\": \"YORKSHIRE\",\n"
                             + "      \"validFrom\": \"2010-02-26\",\n"
                             + "      \"validUntil\": \"2021-01-16\"\n"
                             + "   },\n"
@@ -200,6 +205,7 @@ class AddressServiceTest {
                             + "      \"addressLocality\": \"LEEDS\",\n"
                             + "      \"postalCode\": \"LS10 4QL\",\n"
                             + "      \"addressCountry\": \"GB\",\n"
+                            + "      \"addressRegion\": \"YORKSHIRE\",\n"
                             + "      \"validFrom\": \"2010-02-26\",\n"
                             + "      \"validUntil\": \"2021-01-16\"\n"
                             + "   },\n"
@@ -251,6 +257,7 @@ class AddressServiceTest {
             address1.setAddressLocality("LEEDS");
             address1.setPostalCode("LS10 4QL");
             address1.setAddressCountry("GB");
+            address1.setAddressRegion("YORKSHIRE");
             address1.setValidFrom(LocalDate.of(2010, 2, 26));
             address1.setValidUntil(LocalDate.of(2021, 1, 16));
 


### PR DESCRIPTION
## Proposed changes

### What changed

Bumped cri-lib -> 3.2.1 to now include `addressRegion` in `CanonicalAddress`
Updated unit tests for Java and TS classes that use CanonicalAddress
Amended Integration test to include and check for `addressRegion` in the VC

### Why did it change

We need to implement logic that maps the provided international address fields to the One Login address schema so that the address can be included in a Verifiable Credential (VC) and meet the API contract requirements.

### More Information

`addressRegion` was only added to [CanonicalAddress](https://github.com/govuk-one-login/ipv-cri-lib/blob/main/src/main/java/uk/gov/di/ipv/cri/common/library/persistence/item/CanonicalAddress.java)
`CanonicalAddress` is used for the VC Credential Subject and returns like the image below.

[Address](https://github.com/govuk-one-login/ipv-cri-lib/blob/main/src/main/java/uk/gov/di/ipv/cri/common/library/domain/personidentity/Address.java) did not have `addressRegion` added. `Address` is used for AuditEvents, specifically the `AuditEventContext`. These will still not include `addressRegion` even though the VC does. 

### Issue tracking

- [OJ-2816](https://govukverify.atlassian.net/browse/OJ-2816)

### Evidence ###

![image](https://github.com/user-attachments/assets/b38b1d71-8951-4ee3-9f9e-3001b5b17799)


[OJ-2816]: https://govukverify.atlassian.net/browse/OJ-2816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ