### PR TITLE
OJ-2816: Bump cri-lib to include addressRegion in Address

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.12.3",
-		cri_common_lib           : "3.3.0",
+		cri_common_lib           : "3.4.0",
 		pact_provider_version	 : "4.5.11",
 		webcompere_version       : "2.1.6",
 		slf4j_log4j12_version    : "2.0.13", // For contract test debug

--- a/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandlerTest.java
+++ b/lambdas/issuecredential/src/test/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandlerTest.java
@@ -118,6 +118,7 @@ class IssueCredentialHandlerTest {
         address.setBuildingNumber("114");
         address.setStreetName("Wellington Street");
         address.setPostalCode("LS1 1BA");
+        address.setAddressRegion("Dummy Region");
         AddressItem addressItem = new AddressItem();
 
         List<CanonicalAddress> canonicalAddresses = List.of(address);
@@ -174,6 +175,7 @@ class IssueCredentialHandlerTest {
             assertEquals(address.getAddressLocality(), addressInAuditContext.getAddressLocality());
             assertEquals(address.getPostalCode(), addressInAuditContext.getPostalCode());
             assertEquals(address.getAddressCountry(), addressInAuditContext.getAddressCountry());
+            assertEquals(address.getAddressRegion(), addressInAuditContext.getAddressRegion());
         }
     }
 
@@ -202,6 +204,7 @@ class IssueCredentialHandlerTest {
         address.setBuildingNumber("114");
         address.setStreetName("Wellington Street");
         address.setPostalCode("LS1 1BA");
+        address.setAddressRegion("Dummy Region");
         AddressItem addressItem = new AddressItem();
 
         List<CanonicalAddress> canonicalAddresses = List.of(address);
@@ -274,6 +277,7 @@ class IssueCredentialHandlerTest {
             assertEquals(address.getAddressLocality(), addressInAuditContext.getAddressLocality());
             assertEquals(address.getPostalCode(), addressInAuditContext.getPostalCode());
             assertEquals(address.getAddressCountry(), addressInAuditContext.getAddressCountry());
+            assertEquals(address.getAddressRegion(), addressInAuditContext.getAddressRegion());
         }
     }
 


### PR DESCRIPTION
## Proposed changes

### What changed
Bump cri-lib to 3.4.0, this will ensure addressRegion is also include in the AuditEventContext
<!-- Describe the changes in detail - the "what"-->

### Why did it change

Add addressRegion to audit events. 

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2816](https://govukverify.atlassian.net/browse/OJ-2816)


[OJ-2816]: https://govukverify.atlassian.net/browse/OJ-2816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ