### PR TITLE
OJ-2255: Add localdev environment to the template

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,6 +1,9 @@
 name: Check PR
 
-on: pull_request
+on:
+  workflow_dispatch:
+  pull_request:
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/clean-up-deployments.yml
+++ b/.github/workflows/clean-up-deployments.yml
@@ -26,7 +26,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: Get stale preview stacks
-        uses: govuk-one-login/github-actions/sam/get-stale-stacks@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/sam/get-stale-stacks@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           threshold-days: 14
           stack-name-filter: preview-address-api
@@ -38,7 +38,7 @@ jobs:
 
       - name: Delete stacks
         if: ${{ env.STACKS != null }}
-        uses: govuk-one-login/github-actions/sam/delete-stacks@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/sam/delete-stacks@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           stack-names: ${{ env.STACKS }}
           verbose: true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm ci
 
       - name: Run pre-commit
-        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           all-files: true
           pull-repository: false

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Get stack name
-        uses: govuk-one-login/github-actions/beautify-branch-name@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/beautify-branch-name@d201191485b645ec856a34e5ca48636cf97b2574
         id: get-stack-name
         with:
           usage: Stack name
@@ -29,7 +29,7 @@ jobs:
           verbose: false
 
       - name: Delete stack
-        uses: govuk-one-login/github-actions/sam/delete-stacks@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/sam/delete-stacks@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -1,4 +1,4 @@
-name: Preview
+name: Deploy preview
 
 on:
   workflow_dispatch:
@@ -48,7 +48,7 @@ jobs:
         with:
           template: infrastructure/lambda/template.yaml
           cache-name: address-api
-          pull-repository: true
+          pull-repository: false
           source-dir: lambdas
 
   deploy:
@@ -77,7 +77,7 @@ jobs:
           cache-restore-keys: ${{ needs.build.outputs.cache-restore-keys }}
           s3-prefix: preview
           pull-repository: true
-          disable-rollback: true
+          delete-failed-stack: true
           tags: |
             cri:component=ipv-cri-address-api
             cri:stack-type=preview
@@ -85,5 +85,4 @@ jobs:
             cri:deployment-source=github-actions
           parameters: |
             Environment=dev
-            CodeSigningEnabled=false
             SecretPrefix=pre-merge-test

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -84,5 +84,5 @@ jobs:
             cri:application=Orange
             cri:deployment-source=github-actions
           parameters: |
-            Environment=dev
+            Environment=localdev
             SecretPrefix=pre-merge-test

--- a/.github/workflows/package-for-build.yml
+++ b/.github/workflows/package-for-build.yml
@@ -1,8 +1,8 @@
 name: Package for Build
+
 on:
   push:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
   deploy:

--- a/.github/workflows/package-for-dev.yml
+++ b/.github/workflows/package-for-dev.yml
@@ -1,9 +1,9 @@
-name: Deploy to dev
+name: Package for Dev
+
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - main
-  workflow_dispatch: # deploy manually
+    branches: [main]
 
 jobs:
   deploy:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run tests
         env:
-          ENVIRONMENT: dev
+          ENVIRONMENT: localdev
           AWS_REGION: ${{ inputs.aws-region }}
           STACK_NAME: ${{ inputs.stack-name }}
           API_GATEWAY_ID_PUBLIC: ${{ fromJson(inputs.stack-outputs).PublicAddressApiGatewayId }}

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -15,8 +15,8 @@ on:
 permissions: {}
 
 concurrency:
-  group: integration-tests
-  cancel-in-progress: false
+  group: integration-tests-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   run-tests:

--- a/.github/workflows/run-pact-tests.yml
+++ b/.github/workflows/run-pact-tests.yml
@@ -60,4 +60,3 @@ jobs:
         with:
           name: test-report
           path: lambdas/issuecredential/build/reports/tests/pactTests/
-          

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@0739d7e7a19bae3177cf851ae51944bb4dd53565 #30th Jan 2024
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           projectBaseDir: lambdas/get-addresses
           coverage-location: lambdas/get-addresses/coverage
@@ -98,6 +98,6 @@ jobs:
       security-events: write
     steps:
       - name: Run CodeQL scan
-        uses: govuk-one-login/github-actions/code-quality/codeql@cd7d35dde348251237efbbaee5345e95adef0321
+        uses: govuk-one-login/github-actions/code-quality/codeql@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           languages: javascript-typescript

--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,7 @@ hs_err_pid*
 # Ignore Gradle build output directory
 build
 
-# aws sam deploy ignores
-infrastructure/lambda/samconfig.toml
+# SAM/CloudFormation
 .aws-sam
 
 # mac

--- a/README.md
+++ b/README.md
@@ -81,19 +81,18 @@ The public keys need to be published so that clients:
 
 The environment variable `IPV_CORE_STUB_CRI_ID` with value `address-cri-dev` allows the command below to use keys in `ipv-config` pointing to keys in `di-ipv-cri-address-dev` for the deployed stack in that account.
 
-## Run all tests
-Make sure you have deployed a stack on AWS and provide that `STACK_NAME` below with corresponding `API_GATEWAY_ID_PRIVATE` and `API_GATEWAY_ID_PUBLIC` endpoints
+## Integration tests
 
+Make sure you have deployed a stack to AWS and provide its name in the `STACK_NAME` variable below with the corresponding values for `API_GATEWAY_ID_PRIVATE` and `API_GATEWAY_ID_PUBLIC`.
 
-Below runs by overriding the stub client to `https://cri.core.build.stubs.account.gov.uk` in AWS with stub a client_id ipv-core-stub-aws-stub using DEFAULT_CLIENT_ID env variable
+To initiate journeys for the tests we use the IPV Core Stub, which runs in AWS and is accessible at `https://cri.core.build.stubs.account.gov.uk`.
 
-Use the default `test-resources` stack in TEST_RESOURCES_STACK_NAME unless you have deployed a local test-resources stack 
+The command below overrides the client ID used by the Core Stub to `ipv-core-stub-aws-prod` by setting the `DEFAULT_CLIENT_ID` environment variable.
+
+Optionally set a value for `TEST_RESOURCES_STACK_NAME` if you have deployed a local test resources stack and want to override the default stack named `test-resources`.
 
 ```
-ENVIRONMENT=dev STACK_NAME=xxxx IPV_CORE_STUB_CRI_ID=address-cri-dev  API_GATEWAY_ID_PRIVATE=xxxx API_GATEWAY_ID_PUBLIC=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://cri.core.build.stubs.account.gov.uk" DEFAULT_CLIENT_ID=ipv-core-stub-aws-build APIGW_API_KEY=xxxx TEST_RESOURCES_STACK_NAME=xxxx gradle integration-tests:cucumber
+ENVIRONMENT=localdev STACK_NAME=<your-stack> API_GATEWAY_ID_PRIVATE=<from-your-stack> API_GATEWAY_ID_PUBLIC=<from-your-stack> IPV_CORE_STUB_CRI_ID=address-cri-dev IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL=https://cri.core.build.stubs.account.gov.uk DEFAULT_CLIENT_ID=ipv-core-stub-aws-build APIGW_API_KEY=xxxx TEST_RESOURCES_STACK_NAME= gradle integration-tests:cucumber
 ```
 
-## Run a particular test
-````
-STACK_NAME=xxxx IPV_CORE_STUB_CRI_ID=address-cri-dev ENVIRONMENT=dev API_GATEWAY_ID_PRIVATE=xxxx  API_GATEWAY_ID_PUBLIC=xxxx IPV_CORE_STUB_BASIC_AUTH_USER=xxxx IPV_CORE_STUB_BASIC_AUTH_PASSWORD=xxxx IPV_CORE_STUB_URL="https://di-ipv-core-stub.london.cloudapps.digital" APIGW_API_KEY=xxxx TEST_RESOURCES_STACK_NAME=xxxx gradle cucumber -P tags=@tag-name
-````
+To run a particular test append `-P tags=@tag-name` to the command above specifying the tag you want to select.

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,11 +26,11 @@ sam deploy --stack-name "$stack_name" \
   --capabilities CAPABILITY_IAM \
   --tags \
   cri:component=ipv-cri-address-api \
-  cri:stack-type=dev \
+  cri:stack-type=localdev \
   cri:application=Orange \
   cri:deployment-source=manual \
   --parameter-overrides \
-  Environment=dev \
+  Environment=localdev \
   SecretPrefix=pre-merge-test \
   ${common_stack_name:+CommonStackName=$common_stack_name} \
   ${secret_prefix:+SecretPrefix=$secret_prefix}

--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -4,7 +4,6 @@ info:
   title: "Address Credential Issuer Public API"
 
 paths:
-
   /token:
     post:
       requestBody:
@@ -56,7 +55,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-
       security:
         - api_key:
             Fn::If:
@@ -111,7 +109,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-
       security:
         - api_key:
             Fn::If:

--- a/infrastructure/lambda/samconfig.toml
+++ b/infrastructure/lambda/samconfig.toml
@@ -1,0 +1,26 @@
+version = 0.1
+
+[default.build.parameters]
+cached = true
+parallel = true
+
+[default.deploy.parameters]
+stack_name = "<your-name>-address-api"
+
+capabilities = ["CAPABILITY_IAM"]
+fail_on_empty_changeset = false
+confirm_changeset = false
+s3_prefix = "localdev"
+region = "eu-west-2"
+resolve_s3 = true
+
+parameter_overrides = [
+    "Environment=localdev"
+]
+
+tags = [
+    "cri:component=ipv-cri-address-api",
+    "cri:deployment-source=manual",
+    "cri:application=Orange",
+    "cri:stack-type=localdev"
+]

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -56,63 +56,83 @@ Conditions:
 Globals:
   Function:
     VpcConfig:
-      SecurityGroupIds:
-        - !ImportValue cri-vpc-LambdaSecurityGroup
-      SubnetIds: !Split [ ",", !ImportValue cri-vpc-PrivateSubnets ]
-    PermissionsBoundary: !If
-      - UsePermissionsBoundary
-      - !Ref PermissionsBoundary
-      - !Ref AWS::NoValue
-    CodeSigningConfigArn: !If
-      - UseCodeSigningConfig
-      - !Ref CodeSigningConfigArn
-      - !Ref AWS::NoValue
+      SecurityGroupIds: [!ImportValue cri-vpc-LambdaSecurityGroup]
+      SubnetIds: !Split [",", !ImportValue cri-vpc-PrivateSubnets]
+    PermissionsBoundary:
+      !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
+    CodeSigningConfigArn:
+      !If [UseCodeSigningConfig, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+    Tracing: Active
     Timeout: 30 # seconds
     Runtime: java11
-    Tracing: Active
-    MemorySize: !FindInMap [ MemorySizeMapping, Environment, !Ref 'Environment' ]
-    Architectures:
-      - arm64
-    Environment:
-      Variables:
-        AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
-        DT_CONNECTION_AUTH_TOKEN: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
-        DT_CONNECTION_BASE_URL: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
-        DT_CLUSTER_ID: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
-        DT_LOG_COLLECTION_AUTH_TOKEN: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
-        DT_TENANT: !Sub
-          - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}'
-          - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
-        DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
-        JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
-        AWS_STACK_NAME: !Sub ${AWS::StackName}
-        SECRET_PREFIX: !If [UseSecretPrefix, !Ref SecretPrefix , !Ref AWS::StackName]
-        POWERTOOLS_LOG_LEVEL: INFO
-        SQS_AUDIT_EVENT_PREFIX: !Ref AuditEventNamePrefix
-        POWERTOOLS_METRICS_NAMESPACE: !Ref CriIdentifier
-        COMMON_PARAMETER_NAME_PREFIX: !Ref CommonStackName
-    Layers:
-      - !Sub
-        - '{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}' # or NODEJS_LAYER or PYTHON_LAYER
-        - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
+    Architectures: [arm64]
     AutoPublishAlias: live
     DeploymentPreference:
       Enabled: true
       Type: !Ref LambdaDeploymentPreference
       Role: !GetAtt CodeDeployServiceRole.Arn
+    MemorySize: !FindInMap [MemorySizeMapping, Environment, !Ref Environment]
+    Environment:
+      Variables:
+        AWS_STACK_NAME: !Sub ${AWS::StackName}
+        SECRET_PREFIX: !If [UseSecretPrefix, !Ref SecretPrefix , !Ref AWS::StackName]
+        SQS_AUDIT_EVENT_PREFIX: !Ref AuditEventNamePrefix
+        COMMON_PARAMETER_NAME_PREFIX: !Ref CommonStackName
+        POWERTOOLS_METRICS_NAMESPACE: !Ref CriIdentifier
+        POWERTOOLS_LOG_LEVEL: INFO
+        AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
+        JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+        DT_CONNECTION_AUTH_TOKEN: !Sub
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}"
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
+        DT_CONNECTION_BASE_URL: !Sub
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}"
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
+        DT_CLUSTER_ID: !Sub
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}"
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
+        DT_LOG_COLLECTION_AUTH_TOKEN: !Sub
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}"
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
+        DT_TENANT: !Sub
+          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}"
+          - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
+        DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: true
+    Layers:
+      - !Sub
+        - "{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}"
+        - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
     ProvisionedConcurrencyConfig:
       !If
       - AddProvisionedConcurrency
-      - ProvisionedConcurrentExecutions: !FindInMap [ EnvironmentConfiguration, !Ref Environment, provisionedConcurrency ]
+      - ProvisionedConcurrentExecutions: !FindInMap [EnvironmentConfiguration, !Ref Environment, provisionedConcurrency]
       - !Ref AWS::NoValue
+  Api:
+    TracingEnabled: true
+    OpenApiVersion: 3.0.1
+    MethodSettings:
+      - LoggingLevel: INFO
+        ResourcePath: /*
+        HttpMethod: "*"
+        # Disable data trace in production to avoid logging customer sensitive information
+        DataTraceEnabled: !If [IsProdEnvironment, false, true]
+        MetricsEnabled: true
+        ThrottlingRateLimit: 200
+        ThrottlingBurstLimit: 400
+    AccessLogSetting:
+      Format: >-
+        {
+        "requestId":"$context.requestId",
+        "ip":"$context.identity.sourceIp",
+        "requestTime":"$context.requestTime",
+        "httpMethod":"$context.httpMethod",
+        "path":"$context.path",
+        "routeKey":"$context.routeKey",
+        "status":"$context.status",
+        "protocol":"$context.protocol",
+        "responseLatency":"$context.responseLatency",
+        "responseLength":"$context.responseLength"
+        }
 
 Mappings:
   MemorySizeMapping:
@@ -185,88 +205,40 @@ Resources:
   PublicAddressApi:
     Type: AWS::Serverless::Api
     Properties:
+      Name: !Sub ${AWS::StackName}-PublicAddressApi
       Description: Public Address CRI API
-      MethodSettings:
-        - LoggingLevel: INFO
-          ResourcePath: '/*'
-          HttpMethod: '*'
-          # Disable data trace in production to avoid logging customer sensitive information
-          DataTraceEnabled: !If [IsProdEnvironment, false, true]
-          MetricsEnabled: true
-          ThrottlingRateLimit: 200
-          ThrottlingBurstLimit: 400
-      AccessLogSetting:
-        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${PublicAddressApiAccessLogGroup}'
-        Format: >-
-          {
-          "requestId":"$context.requestId",
-          "ip":"$context.identity.sourceIp",
-          "requestTime":"$context.requestTime",
-          "httpMethod":"$context.httpMethod",
-          "path":"$context.path",
-          "routeKey":"$context.routeKey",
-          "status":"$context.status",
-          "protocol":"$context.protocol",
-          "responseLatency":"$context.responseLatency",
-          "responseLength":"$context.responseLength"
-          }
-      TracingEnabled: true
-      Name: !Sub "${AWS::StackName}-PublicAddressApi"
       StageName: !Ref Environment
+      AccessLogSetting:
+        DestinationArn: !GetAtt PublicAddressApiAccessLogGroup.Arn
       DefinitionBody:
-        openapi: "3.0.1" # workaround to get `sam validate` to work
+        openapi: 3.0.1
         paths: # workaround to get `sam validate` to work
           /never-created:
-            options: { } # workaround to get `sam validate` to work
+            options: { }
         Fn::Transform:
           Name: AWS::Include
           Parameters:
-            Location: './public-api.yaml'
-      OpenApiVersion: 3.0.1
+            Location: ./public-api.yaml
       EndpointConfiguration:
         Type: REGIONAL
 
   PrivateAddressApi:
     Type: AWS::Serverless::Api
     Properties:
+      Name: !Sub ${AWS::StackName}-PrivateAddressApi
       Description: Private Address CRI API
-      MethodSettings:
-        - LoggingLevel: INFO
-          ResourcePath: '/*'
-          HttpMethod: '*'
-          # Disable data trace in production to avoid logging customer sensitive information
-          DataTraceEnabled: !If [IsProdEnvironment, false, true]
-          MetricsEnabled: true
-          ThrottlingRateLimit: 200
-          ThrottlingBurstLimit: 400
-      AccessLogSetting:
-        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${PrivateAddressApiAccessLogGroup}'
-        Format: >-
-          {
-          "requestId":"$context.requestId",
-          "ip":"$context.identity.sourceIp",
-          "requestTime":"$context.requestTime",
-          "httpMethod":"$context.httpMethod",
-          "path":"$context.path",
-          "routeKey":"$context.routeKey",
-          "status":"$context.status",
-          "protocol":"$context.protocol",
-          "responseLatency":"$context.responseLatency",
-          "responseLength":"$context.responseLength"
-          }
-      TracingEnabled: true
-      Name: !Sub "${AWS::StackName}-PrivateAddressApi"
       StageName: !Ref Environment
+      AccessLogSetting:
+        DestinationArn: !GetAtt PrivateAddressApiAccessLogGroup.Arn
       DefinitionBody:
-        openapi: "3.0.1" # workaround to get `sam validate` to work
+        openapi: 3.0.1
         paths: # workaround to get `sam validate` to work
           /never-created:
-            options: { } # workaround to get `sam validate` to work
+            options: { }
         Fn::Transform:
           Name: AWS::Include
           Parameters:
-            Location: './private-api.yaml'
-      OpenApiVersion: 3.0.1
+            Location: ./private-api.yaml
       EndpointConfiguration:
         Type: !If [IsLocalDevEnvironment, REGIONAL, PRIVATE]
       Auth:
@@ -639,7 +611,7 @@ Resources:
     Properties:
       Name: !Sub "/${AWS::StackName}/JwtTtlUnit"
       Type: String
-      Value: !FindInMap [ JwtTtlUnitMapping, Environment, !Ref Environment ]
+      Value: !FindInMap [JwtTtlUnitMapping, Environment, !Ref Environment]
       Description: The unit for the time-to-live for an JWT e.g. (MONTHS)
 
   OrdnanceSurveyAPIURLParameter:
@@ -663,7 +635,7 @@ Resources:
     Properties:
       Name: !Sub "/${AWS::StackName}/release-flags/vc-contains-unique-id"
       Type: String
-      Value: !FindInMap [ VcContainsUniqueIdMapping, Environment, !Ref Environment ]
+      Value: !FindInMap [VcContainsUniqueIdMapping, Environment, !Ref Environment]
       Description: Verifiable Credential Contains UniqueId Mapping
 
   PostcodeLookupFunctionPermission:
@@ -997,7 +969,7 @@ Resources:
                 - codedeploy.amazonaws.com
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda
-      PermissionsBoundary: !If [ UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue ]
+      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
 
 Outputs:
   AddressApiGatewayId:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1,27 +1,21 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Transform: "AWS::Serverless-2016-10-31"
-Description: "Digital Identity IPV CRI Address API"
+Description: Digital Identity IPV CRI Address API
+Transform: AWS::Serverless-2016-10-31 #TODO: Cannot add the LanguageExtensions transform due to a bug in SAM/CF
 
 Parameters:
-  CodeSigningConfigArn:
-    Type: String
-    Default: "none"
-    Description: >
-      The ARN of the Code Signing Config to use, provided by the deployment pipeline
   Environment:
-    Description: "The environment type"
-    Type: "String"
-    AllowedValues:
-      - "dev"
-      - "build"
-      - "staging"
-      - "integration"
-      - "production"
-    ConstraintDescription: must be dev, build, staging, integration or production
+    Type: String
+    Default: dev
+    AllowedValues: [dev, localdev, build, staging, integration, production]
+    ConstraintDescription: Must be dev, localdev, build, staging, integration or production
   LambdaDeploymentPreference:
     Description: "Specifies the configuration to enable gradual Lambda deployments"
     Type: String
     Default: AllAtOnce
+  CodeSigningConfigArn:
+    Description: "The ARN of the Code Signing Config to use, provided by the deployment pipeline"
+    Type: String
+    Default: "none"
   PermissionsBoundary:
     Description: "The ARN of the permissions boundary to apply when creating IAM roles"
     Type: String
@@ -48,17 +42,16 @@ Parameters:
     Default: txma-infrastructure
 
 Conditions:
-  UseCodeSigningConfig: !Not [!Equals [!Ref CodeSigningConfigArn, "none"]]
+  UseSecretPrefix: !Not [!Equals [!Ref SecretPrefix, "none"]]
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, "none"]]
-  IsDevEnvironment: !Equals [!Ref Environment, dev]
+  UseCodeSigningConfig: !Not [!Equals [!Ref CodeSigningConfigArn, "none"]]
+  UseCanaryDeploymentAlarms: !Not [!Equals [!Ref LambdaDeploymentPreference, AllAtOnce]]
+  IsDevEnvironment: !Or [!Equals [!Ref Environment, dev], !Condition IsLocalDevEnvironment]
+  IsLocalDevEnvironment: !Equals [!Ref Environment, localdev]
   IsProdEnvironment: !Equals [!Ref Environment, production]
   IsNotDevEnvironment: !Not [!Condition IsDevEnvironment]
-  UseCanaryDeploymentAlarms: !Not [ !Equals [ !Ref LambdaDeploymentPreference, AllAtOnce ]]
-  UseSecretPrefix: !Not [!Equals [!Ref SecretPrefix, "none"]]
-  AddProvisionedConcurrency: !Not
-    - !Equals
-      - !FindInMap [ EnvironmentConfiguration, !Ref Environment, provisionedConcurrency ]
-      - 0
+  AddProvisionedConcurrency:
+    !Not [!Equals [!FindInMap [EnvironmentConfiguration, !Ref Environment, provisionedConcurrency], 0]]
 
 Globals:
   Function:
@@ -122,7 +115,6 @@ Globals:
       - !Ref AWS::NoValue
 
 Mappings:
-
   MemorySizeMapping:
     Environment:
       dev: 2048
@@ -130,17 +122,22 @@ Mappings:
       staging: 2048
       integration: 2048
       production: 4096
+      localdev: 2048
 
   VcContainsUniqueIdMapping:
     Environment:
-      dev: "true"
-      build: "true"
-      staging: "true"
-      integration: "false"
-      production: "false"
+      dev: true
+      build: true
+      staging: true
+      integration: false
+      production: false
+      localdev: true
 
   EnvironmentConfiguration:
     dev:
+      provisionedConcurrency: 0
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+    localdev:
       provisionedConcurrency: 0
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     build:
@@ -163,6 +160,7 @@ Mappings:
       staging: 6
       integration: 6
       production: 6
+      localdev: 2
 
   # Permitted values: SECONDS,MINUTES,HOURS,DAYS,MONTHS,YEARS
   JwtTtlUnitMapping:
@@ -172,6 +170,7 @@ Mappings:
       staging: MONTHS
       integration: MONTHS
       production: MONTHS
+      localdev: HOURS
 
   OrdnanceSurveyAPIURLMapping:
     Environment:
@@ -180,6 +179,7 @@ Mappings:
       staging: "https://api.os.uk/search/places/v1/postcode"
       integration: "https://api.os.uk/search/places/v1/postcode"
       production: "https://api.os.uk/search/places/v1/postcode"
+      localdev: "https://api.os.uk/search/places/v1/postcode"
 
 Resources:
   PublicAddressApi:
@@ -228,7 +228,6 @@ Resources:
 
   PrivateAddressApi:
     Type: AWS::Serverless::Api
-    Condition: IsNotDevEnvironment
     Properties:
       Description: Private Address CRI API
       MethodSettings:
@@ -269,67 +268,25 @@ Resources:
             Location: './private-api.yaml'
       OpenApiVersion: 3.0.1
       EndpointConfiguration:
-        Type: PRIVATE
+        Type: !If [IsLocalDevEnvironment, REGIONAL, PRIVATE]
       Auth:
         ResourcePolicy:
           CustomStatements:
-            - Action: 'execute-api:Invoke'
-              Effect: Allow
-              Principal: '*'
-              Resource:
-                - 'execute-api:/*'
-            - Action: 'execute-api:Invoke'
-              Effect: Deny
-              Principal: '*'
-              Resource:
-                - 'execute-api:/*'
-              Condition:
-                StringNotEquals:
-                  aws:SourceVpce: !ImportValue cri-vpc-ApiGatewayVpcEndpointId
-
-  DevOnlyAddressApi:
-    Type: AWS::Serverless::Api
-    Condition: IsDevEnvironment
-    Properties:
-      Description: Dev Only Private Address CRI API
-      MethodSettings:
-        - LoggingLevel: INFO
-          ResourcePath: '/*'
-          HttpMethod: '*'
-          DataTraceEnabled: !If [IsProdEnvironment, false, true]
-          MetricsEnabled: true
-          ThrottlingRateLimit: 5
-          ThrottlingBurstLimit: 10
-      AccessLogSetting:
-        DestinationArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${DevOnlyAddressApiAccessLogGroup}'
-        Format: >-
-          {
-          "requestId":"$context.requestId",
-          "ip":"$context.identity.sourceIp",
-          "requestTime":"$context.requestTime",
-          "httpMethod":"$context.httpMethod",
-          "path":"$context.path",
-          "routeKey":"$context.routeKey",
-          "status":"$context.status",
-          "protocol":"$context.protocol",
-          "responseLatency":"$context.responseLatency",
-          "responseLength":"$context.responseLength"
-          }
-      TracingEnabled: true
-      Name: !Sub "${AWS::StackName}-PrivateAddressApi"
-      StageName: !Ref Environment
-      DefinitionBody:
-        openapi: "3.0.1" # workaround to get `sam validate` to work
-        paths: # workaround to get `sam validate` to work
-          /never-created:
-            options: { } # workaround to get `sam validate` to work
-        Fn::Transform:
-          Name: AWS::Include
-          Parameters:
-            Location: './private-api.yaml'
-      OpenApiVersion: 3.0.1
-      EndpointConfiguration:
-        Type: REGIONAL
+            #FIXME: Workaround for lack of the LanguageExtensions transform - need at least one policy in the list
+            - Effect: Allow
+              Resource: execute-api:/*
+              Action: execute-api:Invoke
+              Principal: "*"
+            - !If
+              - IsLocalDevEnvironment
+              - !Ref AWS::NoValue
+              - Effect: Deny
+                Resource: execute-api:/*
+                Action: execute-api:Invoke
+                Principal: "*"
+                Condition:
+                  StringNotEquals:
+                    aws:SourceVpce: !ImportValue cri-vpc-ApiGatewayVpcEndpointId
 
   PublicAddressApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
@@ -347,16 +304,8 @@ Resources:
 
   PrivateAddressApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
-    Condition: IsNotDevEnvironment
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PrivateAddressApi}-private-AccessLogs
-      RetentionInDays: 30
-
-  DevOnlyAddressApiAccessLogGroup:
-    Type: AWS::Logs::LogGroup
-    Condition: IsDevEnvironment
-    Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${DevOnlyAddressApi}-private-AccessLogs
       RetentionInDays: 30
 
   PrivateAddressApiAccessLogGroupSubscriptionFilterCSLS:
@@ -628,11 +577,10 @@ Resources:
   PublicAddressApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
     Condition: IsNotDevEnvironment
-    DependsOn: PublicAddressApiStage
     Properties:
       ApiStages:
         - ApiId: !Ref PublicAddressApi
-          Stage: !Ref Environment
+          Stage: !Ref PublicAddressApi.Stage
       Quota:
         Limit: 500000
         Period: DAY
@@ -643,11 +591,10 @@ Resources:
   PrivateAddressApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
     Condition: IsNotDevEnvironment
-    DependsOn: PrivateAddressApiStage
     Properties:
       ApiStages:
         - ApiId: !Ref PrivateAddressApi
-          Stage: !Ref Environment
+          Stage: !Ref PrivateAddressApi.Stage
       Quota:
         Limit: 500000
         Period: DAY
@@ -894,7 +841,7 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
-#alarm temporarily disabled to avoid false positives and a rollback during deployment
+  ### Alarm temporarily disabled to avoid false positives and a rollback during deployment
   # AddressFunctionCanary5xxErrors:
   #   Type: AWS::CloudWatch::Alarm
   #   Condition: UseCanaryDeploymentAlarms
@@ -1036,8 +983,6 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
-# Code Deploy Service Role
-
   CodeDeployServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -1069,6 +1014,6 @@ Outputs:
 
   PrivateAddressApiGatewayId:
     Description: "API GatewayID of the private Address CRI API"
-    Value: !If [IsNotDevEnvironment, !Ref PrivateAddressApi, !Ref DevOnlyAddressApi]
+    Value: !Ref PrivateAddressApi
     Export:
       Name: !Sub ${AWS::StackName}-PrivateAddressApiGatewayId

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-rootProject.name = "di-ipv-cri-address-api"
+rootProject.name = "ipv-cri-address-api"
 
 // CRI specific lib
 include 'lib'


### PR DESCRIPTION
**OJ-2255: Add localdev environment to the template**

- Delete `DevOnlyAddressApi` and use the private API in dev instead
  - Set the endpoint configuration and access based on the `localdev` variable
  - Add mappings for the `localdev` environment (mirrors `dev`)

- Update the deploy script to use the `localdev` environment
- Add a `samconfig.toml` file with the correct config for `localdev`
- Update the Preview workflow to use the `localdev` environment

- Update integration tests to run with the localdev env
  Remove the `pre_merge` prefix from integration test tags since they are all "pre-merge" and adding the same qualifier to each test doesn't help to differentiate between them.

**OJ-2255: Update APIs**

- Update the API config to match other templates
- Use references to the log groups and stages to let CF create dependencies between the resources and avoid mistakes.
- Use the Globals sections for the API resources to keep the config more concise
- Use the referenceable properties created by SAM to get the API stage names rather than hardcoding the environment value

---

- BAU: Use the latest shared GitHub Actions
  - Update the preview workflow to fix an issue with PR deployments where the lambdas wouldn't get updated.
    Refresh cache on changes to the lambdas source code.
    Retrieve the cache using the keys from the build action.
  - Allow the Check PR workflow to be triggered manually for any branch.

- BAU: Allow integration tests to run in parallel
  This can be reverted now that we have switched to using the test harness for Audit Events and SQS, and there's no longer interference between tests.