### PR TITLE
OJ-2820: vc with international address

### DIFF
--- a/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
@@ -2,6 +2,8 @@ package gov.uk.address.api.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import gov.uk.address.api.util.AddressContext;
+import gov.uk.address.api.util.AddressContextMapper;
 import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
 import uk.gov.di.ipv.cri.common.library.client.HttpHeaders;
 import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
@@ -46,7 +48,23 @@ public class AddressApiClient {
         currentAddress.setPostalCode(postcode);
         currentAddress.setValidFrom(LocalDate.of(2020, 1, 1));
         currentAddress.setAddressCountry(countryCode);
-        currentAddress.setAddressRegion("DummyRegion");
+
+        String requestBody =
+                objectMapper.writeValueAsString(new CanonicalAddress[] {currentAddress});
+
+        String privateApiEndpoint = this.clientConfigurationService.getPrivateApiEndpoint();
+        return sendHttpRequest(
+                requestBuilder(privateApiEndpoint, "address")
+                        .header(SESSION_ID, sessionId)
+                        .PUT(HttpRequest.BodyPublishers.ofString(requestBody))
+                        .build());
+    }
+
+    public HttpResponse<String> sendAddressRequest(String sessionId, AddressContext addressContext)
+            throws IOException, InterruptedException {
+
+        CanonicalAddress currentAddress =
+                AddressContextMapper.mapToCanonicalAddress(addressContext);
 
         String requestBody =
                 objectMapper.writeValueAsString(new CanonicalAddress[] {currentAddress});

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.SignedJWT;
 import gov.uk.address.api.client.AddressApiClient;
+import gov.uk.address.api.util.AddressContext;
+import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -81,9 +83,29 @@ public class AddressSteps {
     public void theUserSelectsAddress() throws IOException, InterruptedException {
         addressContext.setCountryCode("GB");
         this.testContext.setResponse(
+                this.addressApiClient.sendAddressRequest(
+                        this.testContext.getSessionId(),
+                        addressContext.getUprn(),
+                        addressContext.getPostcode(),
+                        addressContext.getCountryCode()));
+    }
+
+    @When("the user enters international address successfully")
+    public void theUserEntersInternationalAddressSuccessfully(DataTable dataTable)
+            throws IOException, InterruptedException {
+        Map<String, String> addressData = dataTable.asMap(String.class, String.class);
+        this.addressContext.setCountryCode(addressData.get("apartmentNumber"));
+        this.addressContext.setRegion(addressData.get("region"));
+        this.addressContext.setLocality(addressData.get("locality"));
+        this.addressContext.setStreetName(addressData.get("streetName"));
+        this.addressContext.setPostcode(addressData.get("postalCode"));
+        this.addressContext.setBuildingName(addressData.get("buildingName"));
+        this.addressContext.setBuildingNumber(addressData.get("buildingNumber"));
+        this.addressContext.setYearFrom(Integer.parseInt(addressData.get("yearFrom")));
+        this.addressContext.setCountryCode(addressData.get("country"));
         this.testContext.setResponse(
                 this.addressApiClient.sendAddressRequest(
-                        this.testContext.getSessionId(), uprn, postcode, countryCode));
+                        this.testContext.getSessionId(), this.addressContext));
     }
 
     @When("the user selects international address")

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -40,10 +40,7 @@ public class AddressSteps {
     private final AddressApiClient addressApiClient;
     private final CriTestContext testContext;
     private final String addressStartJsonSchema;
-
-    private String postcode;
-    private String uprn;
-    private String countryCode;
+    private AddressContext addressContext;
 
     public AddressSteps(
             ClientConfigurationService clientConfigurationService, CriTestContext testContext)
@@ -58,6 +55,7 @@ public class AddressSteps {
                                         AddressSteps.class.getResource(ADDRESS_START_SCHEMA_FILE))
                                 .toURI());
         this.addressStartJsonSchema = Files.readString(schemaPath);
+        this.addressContext = new AddressContext();
     }
 
     @When("the user performs a postcode lookup for post code {string}")
@@ -74,14 +72,15 @@ public class AddressSteps {
         JsonNode jsonNode = objectMapper.readTree(this.testContext.getResponse().body());
         assertEquals(200, this.testContext.getResponse().statusCode());
         assertNotNull(jsonNode.get(0).get("uprn").asText());
-        uprn = jsonNode.get(0).get("uprn").asText();
         assertEquals(postcode, jsonNode.get(0).get("postalCode").asText());
-        this.postcode = jsonNode.get(0).get("postalCode").asText();
+        addressContext.setUprn(jsonNode.get(0).get("uprn").asText());
+        addressContext.setPostcode(jsonNode.get(0).get("postalCode").asText());
     }
 
     @When("the user selects address")
     public void theUserSelectsAddress() throws IOException, InterruptedException {
-        countryCode = "GB";
+        addressContext.setCountryCode("GB");
+        this.testContext.setResponse(
         this.testContext.setResponse(
                 this.addressApiClient.sendAddressRequest(
                         this.testContext.getSessionId(), uprn, postcode, countryCode));
@@ -89,17 +88,24 @@ public class AddressSteps {
 
     @When("the user selects international address")
     public void theUserSelectsInternationalAddress() throws IOException, InterruptedException {
-        countryCode = "IA";
+        addressContext.setCountryCode("KE");
         this.testContext.setResponse(
                 this.addressApiClient.sendAddressRequest(
-                        this.testContext.getSessionId(), uprn, postcode, countryCode));
+                        this.testContext.getSessionId(),
+                        addressContext.getUprn(),
+                        addressContext.getPostcode(),
+                        addressContext.getCountryCode()));
     }
 
     @When("the user selects address without country code")
     public void theUserSelectsAddressWithoutCountryCode() throws IOException, InterruptedException {
+        addressContext.setCountryCode(null);
         this.testContext.setResponse(
                 this.addressApiClient.sendAddressRequest(
-                        this.testContext.getSessionId(), uprn, postcode, null));
+                        this.testContext.getSessionId(),
+                        addressContext.getUprn(),
+                        addressContext.getPostcode(),
+                        addressContext.getCountryCode()));
     }
 
     @Then("the address is saved successfully")
@@ -218,11 +224,14 @@ public class AddressSteps {
 
         assertEquals("VerifiableCredential", payload.at("/vc/type/0").asText());
         assertEquals("AddressCredential", payload.at("/vc/type/1").asText());
-        assertEquals(postcode, payload.at("/vc/credentialSubject/address/0/postalCode").asText());
         assertEquals(
-                countryCode, payload.at("/vc/credentialSubject/address/0/addressCountry").asText());
+                addressContext.getPostcode(),
+                payload.at("/vc/credentialSubject/address/0/postalCode").asText());
         assertEquals(
-                "DummyRegion",
+                addressContext.getCountryCode(),
+                payload.at("/vc/credentialSubject/address/0/addressCountry").asText());
+        assertEquals(
+                addressContext.getRegion(),
                 payload.at("/vc/credentialSubject/address/0/addressRegion").asText());
     }
 

--- a/integration-tests/src/test/java/gov/uk/address/api/util/AddressContext.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/util/AddressContext.java
@@ -1,0 +1,99 @@
+package gov.uk.address.api.util;
+
+public class AddressContext {
+    private static final String NO_REGION_REPRESENTED_WITH_BLANK = "";
+    private String uprn;
+    private String postcode;
+    private String countryCode;
+    private String region;
+    private String locality;
+    private String streetName;
+    private String buildingName;
+    private String buildingNumber;
+    private String apartmentNumber;
+    private int yearFrom;
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getLocality() {
+        return locality;
+    }
+
+    public void setLocality(String locality) {
+        this.locality = locality;
+    }
+
+    public String getStreetName() {
+        return streetName;
+    }
+
+    public void setStreetName(String streetName) {
+        this.streetName = streetName;
+    }
+
+    public String getBuildingName() {
+        return buildingName;
+    }
+
+    public void setBuildingName(String buildingName) {
+        this.buildingName = buildingName;
+    }
+
+    public String getBuildingNumber() {
+        return buildingNumber;
+    }
+
+    public void setBuildingNumber(String buildingNumber) {
+        this.buildingNumber = buildingNumber;
+    }
+
+    public String getApartmentNumber() {
+        return apartmentNumber;
+    }
+
+    public void setApartmentNumber(String apartmentNumber) {
+        this.apartmentNumber = apartmentNumber;
+    }
+
+    public int getYearFrom() {
+        return yearFrom;
+    }
+
+    public void setYearFrom(int yearFrom) {
+        this.yearFrom = yearFrom;
+    }
+
+    public AddressContext() {
+        this.region = NO_REGION_REPRESENTED_WITH_BLANK;
+    }
+
+    public String getUprn() {
+        return uprn;
+    }
+
+    public void setUprn(String uprn) {
+        this.uprn = uprn;
+    }
+
+    public String getPostcode() {
+        return postcode;
+    }
+
+    public void setPostcode(String postcode) {
+        this.postcode = postcode;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public void setCountryCode(String countryCode) {
+        this.countryCode = countryCode;
+    }
+}

--- a/integration-tests/src/test/java/gov/uk/address/api/util/AddressContextMapper.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/util/AddressContextMapper.java
@@ -1,0 +1,28 @@
+package gov.uk.address.api.util;
+
+import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
+
+import java.time.LocalDate;
+import java.time.Year;
+
+public class AddressContextMapper {
+    public static CanonicalAddress mapToCanonicalAddress(AddressContext request) {
+        CanonicalAddress canonicalAddress = new CanonicalAddress();
+
+        canonicalAddress.setAddressRegion(request.getRegion());
+        canonicalAddress.setAddressLocality(request.getLocality());
+        canonicalAddress.setStreetName(request.getStreetName());
+        canonicalAddress.setPostalCode(request.getPostcode());
+        canonicalAddress.setBuildingNumber(request.getBuildingNumber());
+        canonicalAddress.setBuildingName(request.getBuildingName());
+        canonicalAddress.setSubBuildingName(request.getApartmentNumber());
+        canonicalAddress.setValidFrom(yearFrom(request.getYearFrom()));
+        canonicalAddress.setAddressCountry(request.getCountryCode());
+
+        return canonicalAddress;
+    }
+
+    private static LocalDate yearFrom(int year) {
+        return Year.of(year).atMonth(1).atDay(1);
+    }
+}

--- a/integration-tests/src/test/resources/features/AddressAPIHappyPath.feature
+++ b/integration-tests/src/test/resources/features/AddressAPIHappyPath.feature
@@ -80,8 +80,51 @@ Feature: Address API happy path test
       | 23                         | CA14 5PH     |
       | 1000                       | S62 5AB      |
 
+  @international_address_api_happy_with_header
+  Scenario: International Address API journey
+    Given user has the test-identity 197 and context of "international_user" in the form of a signed JWT string
+    # Session
+    When user sends a POST request to session end point with txma header
+    Then user gets a session-id
+
+    # TXMA event
+    When user sends a GET request to events end point for "IPV_ADDRESS_CRI_START"
+    And a valid START event is returned in the response with txma header
+    Then START TxMA event is validated against schema
+
+    # Addresses
+    When user requests lands on /addresses
+    Then response should contain addresses and context from the personIdentityTable
+
+    # Address
+    When the user enters international address successfully
+      | Field                     | Value                     |
+      | apartmentNumber           | 4                         |
+      | buildingNumber            | 10                        |
+      | buildingName              | Kilimanjaro Apartments    |
+      | streetName                | Ngong Road                |
+      | country                   | KE                        |
+      | region                    | Nairobi County            |
+      | locality                  | Nairobi                   |
+      | postalCode                | 00100                     |
+      | yearFrom                  | 2020                      |
+
+    Then the address is saved successfully
+
+    # Authorization
+    When user sends a GET request to authorization end point
+    And a valid authorization code is returned in the response
+
+    # Access token
+    When user sends a POST request to token end point
+    And a valid access token code is returned in the response
+
+    # Credential Issued
+    When user sends a POST request to Credential Issue end point with a valid access token
+    And a valid JWT is returned in the response
+
   @international_address_api_happy
-  Scenario: Temporary Country Code Only International Address API journey
+  Scenario: International Address API journey
     Given user has the test-identity 197 and context of "international_user" in the form of a signed JWT string
     # Session
     When user sends a POST request to session end point
@@ -96,12 +139,19 @@ Feature: Address API happy path test
     When user requests lands on /addresses
     Then response should contain addresses and context from the personIdentityTable
 
-    # Postcode lookup
-    When the user performs a postcode lookup for post code "SW1A 2AA"
-    Then user receives a list of addresses containing "SW1A 2AA"
-
     # Address
-    When the user selects international address
+    When the user enters international address successfully
+      | Field                     | Value                     |
+      | apartmentNumber           | 4                         |
+      | buildingNumber            | 10                        |
+      | buildingName              | Kilimanjaro Apartments    |
+      | streetName                | Ngong Road                |
+      | country                   | KE                        |
+      | region                    | Nairobi County            |
+      | locality                  | Nairobi                   |
+      | postalCode                | 00100                     |
+      | yearFrom                  | 2020                      |
+
     Then the address is saved successfully
 
     # Authorization


### PR DESCRIPTION
## Proposed changes

- Removal of postcode lookup as part of testing international addresses
- Additional scenario with TxMA headers for international addresses

### What changed

Added a new step `When the user enters international address successfully`
Updated integration test to use an addressContext class

### Why did it change

This ticket is to add full integration tests of the international addresses piece of work.

- [OJ-2820](https://govukverify.atlassian.net/browse/OJ-2820)

[OJ-2820]: https://govukverify.atlassian.net/browse/OJ-2820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ