### PR TITLE
OJ-2974: Add isUkAddress to VC_ISSUED audit event

### DIFF
--- a/integration-tests/src/test/resources/features/AddressAPIHappyPath.feature
+++ b/integration-tests/src/test/resources/features/AddressAPIHappyPath.feature
@@ -37,6 +37,10 @@ Feature: Address API happy path test
     When user sends a POST request to Credential Issue end point with a valid access token
     And a valid JWT is returned in the response
 
+    # TXMA event
+    When user sends a GET request to events end point for "IPV_ADDRESS_CRI_VC_ISSUED"
+    Then VC_ISSUED TxMA event is validated against schema with isUkAddress "true"
+
   @address_api_happy
   Scenario Outline: Basic Address API journey
     Given user has the test-identity <testUserDataSheetRowNumber> in the form of a signed JWT string
@@ -73,6 +77,10 @@ Feature: Address API happy path test
     # Credential Issued
     When user sends a POST request to Credential Issue end point with a valid access token
     And a valid JWT is returned in the response
+
+    # TXMA event
+    When user sends a GET request to events end point for "IPV_ADDRESS_CRI_VC_ISSUED"
+    Then VC_ISSUED TxMA event is validated against schema with isUkAddress "true"
 
     Examples:
       | testUserDataSheetRowNumber | testPostCode |
@@ -123,6 +131,10 @@ Feature: Address API happy path test
     When user sends a POST request to Credential Issue end point with a valid access token
     And a valid JWT is returned in the response
 
+    # TXMA event
+    When user sends a GET request to events end point for "IPV_ADDRESS_CRI_VC_ISSUED"
+    Then VC_ISSUED TxMA event is validated against schema with isUkAddress "false"
+
   @international_address_api_happy
   Scenario: International Address API journey
     Given user has the test-identity 197 and context of "international_user" in the form of a signed JWT string
@@ -165,3 +177,7 @@ Feature: Address API happy path test
     # Credential Issued
     When user sends a POST request to Credential Issue end point with a valid access token
     And a valid JWT is returned in the response
+
+    # TXMA event
+    When user sends a GET request to events end point for "IPV_ADDRESS_CRI_VC_ISSUED"
+    Then VC_ISSUED TxMA event is validated against schema with isUkAddress "false"

--- a/integration-tests/src/test/resources/schema/IPV_ADDRESS_CRI_START.json
+++ b/integration-tests/src/test/resources/schema/IPV_ADDRESS_CRI_START.json
@@ -50,6 +50,22 @@
         }
       },
       "required": ["device_information"]
+    },
+    "extensions": {
+      "type": "object",
+      "properties": {
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "context": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "required": [

--- a/integration-tests/src/test/resources/schema/IPV_ADDRESS_CRI_VC_ISSUED.json
+++ b/integration-tests/src/test/resources/schema/IPV_ADDRESS_CRI_VC_ISSUED.json
@@ -1,0 +1,85 @@
+{
+  "type": "object",
+  "properties": {
+    "event_name": {
+      "type": "string"
+    },
+    "user": {
+      "type": "object",
+      "properties": {
+        "user_id": {
+          "type": "string"
+        },
+        "session_id": {
+          "type": "string"
+        },
+        "persistent_session_id": {
+          "type": "string"
+        },
+        "govuk_signin_journey_id": {
+          "type": "string"
+        },
+        "ip_address": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "user_id",
+        "session_id",
+        "persistent_session_id",
+        "govuk_signin_journey_id",
+        "ip_address"
+      ]
+    },
+    "timestamp": {
+      "type": "integer"
+    },
+    "event_timestamp_ms": {
+      "type": "integer"
+    },
+    "component_id": {
+      "type": "string"
+    },
+    "restricted": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "addressCountry": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "extensions": {
+      "type": "object",
+      "properties": {
+        "addressesEntered": {
+          "type": "integer"
+        },
+        "iss": {
+          "type": "string"
+        },
+        "isUkAddress": {
+          "type": "boolean"
+        }
+      },
+      "required": ["addressesEntered", "iss", "isUkAddress"]
+    }
+  },
+  "required": [
+    "event_name",
+    "user",
+    "timestamp",
+    "event_timestamp_ms",
+    "component_id",
+    "extensions"
+  ],
+  "additionalProperties": false
+}

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialService.java
@@ -13,6 +13,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
 import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.ADDRESS_CREDENTIAL_TYPE;
@@ -67,12 +68,27 @@ public class VerifiableCredentialService {
                         configurationService.getVerifiableCredentialIssuer(),
                         "VC issuer must not be null"),
                 "addressesEntered",
-                Objects.nonNull(addresses) ? addresses.size() : 0);
+                Objects.nonNull(addresses) ? addresses.size() : 0,
+                "isUkAddress",
+                isUkAddress(getFirstAddressCountryCode(addresses)));
     }
 
     private Object[] convertAddresses(List<CanonicalAddress> addresses) {
         return addresses.stream()
                 .map(address -> objectMapper.convertValue(address, Map.class))
                 .toArray();
+    }
+
+    private String getFirstAddressCountryCode(final List<CanonicalAddress> addresses) {
+        if (addresses == null
+                || addresses.get(0) == null
+                || addresses.get(0).getAddressCountry() == null) {
+            return "";
+        }
+        return addresses.get(0).getAddressCountry();
+    }
+
+    private boolean isUkAddress(final String countryCode) {
+        return Stream.of("GB", "GG", "JE", "IM").anyMatch(countryCode::equalsIgnoreCase);
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

- Added isUkAddress to VC_ISSUED audit event extensions, this is set to true for UK, IoM and channel islands. 
- Added VC_ISSUED json schema validation to integration tests.
- Fix: Added context field to START event schema validation

### Why did it change

So that we can differentiate between UK and international addresses for analytics.

### Issue tracking
- [OJ-2974](https://govukverify.atlassian.net/browse/OJ-2974)

[OJ-2974]: https://govukverify.atlassian.net/browse/OJ-2974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ