### PR TITLE
OJ-3001: Temporarily lower the secrets manager caching

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -296,6 +296,8 @@ Resources:
           - [!Ref AWS::NoValue]
       Environment:
         Variables:
+          CONFIG_SERVICE_SSM_OPTIMIZED_CACHE_AGE_MIN_MINUTES: "0"
+          CONFIG_SERVICE_SSM_OPTIMIZED_CACHE_AGE_MAX_MINUTES: "1"
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-postcode-lookup"
           SQS_AUDIT_EVENT_QUEUE_URL:
             Fn::ImportValue: !Sub ${TxmaStackName}-AuditEventQueueUrl


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add env vars to override cache min and max age for secrets manager

### Why did it change

So that new API key takes effect within a minute

### Screenshots

<img width="858" alt="image" src="https://github.com/user-attachments/assets/338c0a8e-a865-44b0-9c24-489eb282e99f" />

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3001](https://govukverify.atlassian.net/browse/OJ-3001)


[OJ-3001]: https://govukverify.atlassian.net/browse/OJ-3001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ