### PR TITLE
OJ-3014: Open Telemetry Java Lambdas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ subprojects {
 		webcompere
 		cri_common_lib
 		pact_tests
+		otel
 	}
 
 	// The dynamodb enhanced package loads the apache-client as well as the spi-client, so
@@ -114,6 +115,9 @@ subprojects {
 
 		pact_tests "au.com.dius.pact.provider:junit5:${dependencyVersions.pact_provider_version}",
 				"au.com.dius.pact:provider:${dependencyVersions.pact_provider_version}"
+
+		otel "io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2-autoconfigure:2.12.0-alpha",
+				"io.opentelemetry.instrumentation:opentelemetry-java-http-client:2.12.0-alpha"
 	}
 
 	test {

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -103,6 +103,7 @@ Globals:
           - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}"
           - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: true
+        OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING: "true"
     Layers:
       - !Sub
         - "{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}"

--- a/lambdas/address/build.gradle
+++ b/lambdas/address/build.gradle
@@ -5,6 +5,8 @@ plugins {
 }
 
 dependencies {
+	runtimeOnly configurations.otel
+
 	implementation configurations.cri_common_lib,
 			project(":lib"),
 			configurations.aws,

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -5,6 +5,8 @@ plugins {
 }
 
 dependencies {
+	runtimeOnly configurations.otel
+
 	implementation configurations.cri_common_lib,
 			project(":lib"),
 			configurations.aws,

--- a/lambdas/postcode-lookup/build.gradle
+++ b/lambdas/postcode-lookup/build.gradle
@@ -5,6 +5,8 @@ plugins {
 }
 
 dependencies {
+	implementation configurations.otel
+
 	implementation project(":lib"),
 			configurations.cri_common_lib,
 			configurations.aws,

--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
@@ -56,6 +56,7 @@ import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.INVALID_POSTC
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_EXPIRED;
 import static uk.gov.di.ipv.cri.common.library.error.ErrorResponse.SESSION_NOT_FOUND;
 
+@SuppressWarnings("javaarchitecture:S7091")
 public class PostcodeLookupHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 

--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
@@ -6,6 +6,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.ErrorObject;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.httpclient.JavaHttpClientTelemetry;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
@@ -79,10 +81,14 @@ public class PostcodeLookupHandler
                         clientProviderFactory.getSecretsProvider());
 
         HttpClient httpClient =
-                HttpClient.newBuilder()
-                        .version(HttpClient.Version.HTTP_2)
-                        .connectTimeout(Duration.ofSeconds(CONNECTION_TIMEOUT_SECONDS))
-                        .build();
+                JavaHttpClientTelemetry.builder(GlobalOpenTelemetry.get())
+                        .build()
+                        .newHttpClient(
+                                HttpClient.newBuilder()
+                                        .version(HttpClient.Version.HTTP_2)
+                                        .connectTimeout(
+                                                Duration.ofSeconds(CONNECTION_TIMEOUT_SECONDS))
+                                        .build());
 
         this.eventProbe = new EventProbe();
 


### PR DESCRIPTION
## Proposed changes

### What changed

Add OTEL tracing to AWS SDK and Java Http (for Java Lambdas only)

This implementation was copied from here: https://github.com/govuk-one-login/ipv-core-back/pull/2776

### Why did it change

This adds instrumentation to the AWS SDK and the Java HTTP client, so that we can see more details traces in dynatrace.

### Issue tracking
- [OJ-3014](https://govukverify.atlassian.net/browse/OJ-3014)

### Screenshots
![image](https://github.com/user-attachments/assets/291d6ac1-83f2-4166-982a-2f138e765e9e)
![image](https://github.com/user-attachments/assets/8817d1e5-3576-4234-8366-f918dc78b46c)
![image](https://github.com/user-attachments/assets/0ae17500-99d7-4d74-b61e-59f4abd895e3)


[OJ-3014]: https://govukverify.atlassian.net/browse/OJ-3014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ