### PR TITLE
OJ-3033: disable trace annotation capturing

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -85,6 +85,8 @@ Globals:
         COMMON_PARAMETER_NAME_PREFIX: !Ref CommonStackName
         POWERTOOLS_METRICS_NAMESPACE: !Ref CriIdentifier
         POWERTOOLS_LOG_LEVEL: INFO
+        POWERTOOLS_TRACER_CAPTURE_RESPONSE: false
+        POWERTOOLS_TRACER_CAPTURE_ERROR: false
         AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
         DT_CONNECTION_AUTH_TOKEN: !Sub


### PR DESCRIPTION
## Proposed changes

Disable annotation from capturing their responses and exception as tracing metadata globally by s
etting environment variables:

POWERTOOLS_TRACER_CAPTURE_RESPONSE and POWERTOOLS_TRACER_CAPTURE_ERROR to false see: https://docs.powertools.aws.dev/lambda/java/core/tracing/

## Why
see comments on: https://govukverify.atlassian.net/browse/OJ-3033

These are extract steps, to ensure the leakage from tracing is prevented, currently leaking can be through
api-access-logs are that would be addressed in a future PR

- [OJ-3033](https://govukverify.atlassian.net/browse/OJ-3033)

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3033]: https://govukverify.atlassian.net/browse/OJ-3033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ