### PR TITLE
OJ-3033: Add redact policy to private access logs

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -275,6 +275,28 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PrivateAddressApi}-private-AccessLogs
       RetentionInDays: 30
+      DataProtectionPolicy:
+        Name: uk_postcode_data_protection_policy
+        Description: ""
+        Version: "2021-06-01"
+        Statement:
+          - Sid: audit-policy
+            DataIdentifier:
+              - postcode
+            Operation:
+              Audit:
+                FindingsDestination: { }
+          - Sid: redact-policy
+            DataIdentifier:
+              - postcode
+            Operation:
+              Deidentify:
+                MaskConfig: { }
+        Configuration:
+          CustomDataIdentifier:
+            - Name: postcode
+              Regex: "/(integration|production)\\/postcode-lookup\\/([A-Z]{1,2}[0-9][A-Z0-9]?)[:+%20]?([0-9][A-Z]{2})"
+
 
   PrivateAddressApiAccessLogGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
## Proposed changes

Requests to /postcode-lookup/{postode} logs the postcode value in Splunk which users have entered. This PR redacts valid postcode values by masking them. 

### What changed

Stop logging postcode values from  api gateway private access logs

### Why did it change

Postcode is considered to be PII, an actor can potential derive other information about the user. 


- [OJ-3033](https://govukverify.atlassian.net/browse/OJ-3033)



[OJ-3033]: https://govukverify.atlassian.net/browse/OJ-3033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ