### PR TITLE
OJ-3033: Use wildcard

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -297,7 +297,7 @@ Resources:
         Configuration:
           CustomDataIdentifier:
             - Name: postcode
-              Regex: "/(integration|production)\\/postcode-lookup\\/([A-Z]{1,2}[0-9][A-Z0-9]?)[:+%20]?([0-9][A-Z]{2})"
+              Regex: "/(integration|production)\\/postcode-lookup\\/.*"
 
 
   PrivateAddressApiAccessLogGroupSubscriptionFilterCSLS:


### PR DESCRIPTION
Instead of trying to match with valid postcode, just wildcard anything after the postcode-lookup/ request path

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

Instead of trying to match with valid postcode, just wildcard anything after the postcode-lookup/ request path

### What changed

Update to https://github.com/govuk-one-login/ipv-cri-address-api/pull/1189

- [OJ-3033](https://govukverify.atlassian.net/browse/OJ-3033)


- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3033]: https://govukverify.atlassian.net/browse/OJ-3033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ