### PR TITLE
OJ-3033: remove tracing annotation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,6 @@ subprojects {
 
 		powertools "software.amazon.lambda:powertools-logging:${dependencyVersions.powertools_version}",
 				"software.amazon.lambda:powertools-metrics:${dependencyVersions.powertools_version}",
-				"software.amazon.lambda:powertools-tracing:${dependencyVersions.powertools_version}",
 				"software.amazon.lambda:powertools-parameters:${dependencyVersions.powertools_version}"
 
 		nimbus "com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
@@ -114,11 +113,6 @@ subprojects {
 
 		pact_tests "au.com.dius.pact.provider:junit5:${dependencyVersions.pact_provider_version}",
 				"au.com.dius.pact:provider:${dependencyVersions.pact_provider_version}"
-	}
-
-	test {
-		// Configures environment variable to avoid initialization of AWS X-Ray segments for each tests
-		environment "LAMBDA_TASK_ROOT", "handler"
 	}
 
 	tasks.register("pactTests", Test) {

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -113,7 +113,7 @@ Globals:
       - ProvisionedConcurrentExecutions: !FindInMap [EnvironmentConfiguration, !Ref Environment, provisionedConcurrency]
       - !Ref AWS::NoValue
   Api:
-    TracingEnabled: true
+    TracingEnabled: false
     OpenApiVersion: 3.0.1
     MethodSettings:
       - LoggingLevel: INFO

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -85,8 +85,6 @@ Globals:
         COMMON_PARAMETER_NAME_PREFIX: !Ref CommonStackName
         POWERTOOLS_METRICS_NAMESPACE: !Ref CriIdentifier
         POWERTOOLS_LOG_LEVEL: INFO
-        POWERTOOLS_TRACER_CAPTURE_RESPONSE: false
-        POWERTOOLS_TRACER_CAPTURE_ERROR: false
         AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
         DT_CONNECTION_AUTH_TOKEN: !Sub

--- a/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
+++ b/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
@@ -14,7 +14,6 @@ import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.metrics.Metrics;
-import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.cri.address.library.exception.AddressProcessingException;
 import uk.gov.di.ipv.cri.address.library.service.AddressService;
 import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
@@ -89,7 +88,6 @@ public class AddressHandler
     @Override
     @Logging(correlationIdPath = CorrelationIdPathConstants.API_GATEWAY_REST, clearState = true)
     @Metrics(captureColdStart = true)
-    @Tracing
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
@@ -19,7 +19,6 @@ import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.metrics.Metrics;
-import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.cri.address.api.exception.CredentialRequestException;
 import uk.gov.di.ipv.cri.address.api.service.VerifiableCredentialService;
 import uk.gov.di.ipv.cri.address.library.persistence.item.AddressItem;
@@ -124,7 +123,6 @@ public class IssueCredentialHandler
     @Override
     @Logging(correlationIdPath = CorrelationIdPathConstants.API_GATEWAY_REST, clearState = true)
     @Metrics(captureColdStart = true)
-    @Tracing
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
 

--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
@@ -11,7 +11,6 @@ import org.apache.logging.log4j.LogManager;
 import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
 import software.amazon.lambda.powertools.logging.Logging;
 import software.amazon.lambda.powertools.metrics.Metrics;
-import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.cri.address.api.exceptions.PostcodeLookupBadRequestException;
 import uk.gov.di.ipv.cri.address.api.exceptions.PostcodeLookupProcessingException;
 import uk.gov.di.ipv.cri.address.api.exceptions.PostcodeLookupTimeoutException;
@@ -117,7 +116,6 @@ public class PostcodeLookupHandler
     @Override
     @Logging(correlationIdPath = CorrelationIdPathConstants.API_GATEWAY_REST, clearState = true)
     @Metrics(captureColdStart = true)
-    @Tracing
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         String sessionId = input.getHeaders().get(SESSION_ID);

--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupService.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupService.java
@@ -7,7 +7,6 @@ import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.http.SdkHttpMethod;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
-import software.amazon.lambda.powertools.tracing.Tracing;
 import uk.gov.di.ipv.cri.address.api.exceptions.PostcodeLookupBadRequestException;
 import uk.gov.di.ipv.cri.address.api.exceptions.PostcodeLookupProcessingException;
 import uk.gov.di.ipv.cri.address.api.exceptions.PostcodeLookupTimeoutException;
@@ -72,7 +71,6 @@ public class PostcodeLookupService {
         this.eventProbe = eventProbe;
     }
 
-    @Tracing
     public List<CanonicalAddress> lookupPostcode(String postcode)
             throws PostcodeValidationException, PostcodeLookupProcessingException,
                     JsonProcessingException, PostcodeLookupBadRequestException {


### PR DESCRIPTION
## Proposed changes

Remove X-Ray tracing, it was observed that the request have the paths which contain postcode.

see comments on: https://govukverify.atlassian.net/browse/OJ-3033


### Why did it change

Postcode is considered by the programme as PII, this is one of the steps that can reduce this

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks