### PR TITLE
OJ-3014: Add OTEL to Address and IssueCredential Java Lambdas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ subprojects {
 		webcompere
 		cri_common_lib
 		pact_tests
+		otel
 	}
 
 	// The dynamodb enhanced package loads the apache-client as well as the spi-client, so
@@ -113,6 +114,9 @@ subprojects {
 
 		pact_tests "au.com.dius.pact.provider:junit5:${dependencyVersions.pact_provider_version}",
 				"au.com.dius.pact:provider:${dependencyVersions.pact_provider_version}"
+
+		otel "io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2-autoconfigure:2.12.0-alpha",
+				"io.opentelemetry.instrumentation:opentelemetry-java-http-client:2.12.0-alpha"
 	}
 
 	tasks.register("pactTests", Test) {

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -103,6 +103,7 @@ Globals:
           - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}"
           - SecretArn: !FindInMap [EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn]
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: true
+        OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING: "true"
     ProvisionedConcurrencyConfig:
       !If
       - AddProvisionedConcurrency

--- a/lambdas/address/build.gradle
+++ b/lambdas/address/build.gradle
@@ -5,6 +5,8 @@ plugins {
 }
 
 dependencies {
+	runtimeOnly configurations.otel
+
 	implementation configurations.cri_common_lib,
 			project(":lib"),
 			configurations.aws,

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -5,6 +5,8 @@ plugins {
 }
 
 dependencies {
+	runtimeOnly configurations.otel
+
 	implementation configurations.cri_common_lib,
 			project(":lib"),
 			configurations.aws,


### PR DESCRIPTION
## Proposed changes

### What changed

Adding OpenTelemetery to Address and IssueCredential Lambdas. This uses auto instrumentation.

The PostcodeLookup handler is slightly more complex and will follow in a different PR.

### Why did it change

This adds instrumentation to Address and IssueCredential Java Lambdas so that we can see more details traces in dynatrace.

This follows the previously reverted PR: https://github.com/govuk-one-login/ipv-cri-address-api/pull/1185

### Issue tracking

- [OJ-3014](https://govukverify.atlassian.net/browse/OJ-3014)


[OJ-3014]: https://govukverify.atlassian.net/browse/OJ-3014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ