### PR TITLE
Oj 3037 post postcode lookup endpoint

### DIFF
--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -58,6 +58,53 @@ paths:
         contentHandling: "CONVERT_TO_TEXT"
         type: "aws_proxy"
 
+  /postcode-lookup:
+    post:
+      parameters:
+        - in: header
+          name: "session_id"
+          schema:
+            type: string
+            format: uuid
+          required: true
+        - $ref: '#/components/parameters/AuditHeader'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Postcode"
+        required: true
+      responses:
+        "400":
+          description: "400 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: "500 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "201":
+          description: "201 response"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PostcodeLookupResponse"
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PostcodeLookupFunction.Arn}:live/invocations
+        responses:
+          default:
+            statusCode: "200"
+        passthroughBehavior: "when_no_match"
+        contentHandling: "CONVERT_TO_TEXT"
+        type: "aws_proxy"
+
   /postcode-lookup/{postcode}:
     get:
       parameters:
@@ -329,6 +376,13 @@ components:
       minItems: 1
       items:
         $ref: "#/components/schemas/CanonicalAddress"
+    Postcode:
+      title: "Postcode"
+      type: "object"
+      properties:
+        postcode:
+          type: "string"
+          example: "SW1A 1AA"
     Address:
       title: "Address Update Request"
       type: "array"

--- a/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
@@ -33,6 +33,19 @@ public class AddressApiClient {
 
         String privateApiEndpoint = this.clientConfigurationService.getPrivateApiEndpoint();
         return sendHttpRequest(
+                requestBuilder(privateApiEndpoint, "postcode-lookup")
+                        .header(SESSION_ID, sessionId)
+                        .POST(
+                                HttpRequest.BodyPublishers.ofString(
+                                        "{\"postcode\": \"" + postcode + "\"}"))
+                        .build());
+    }
+
+    public HttpResponse<String> sendPostCodeLookUpGETRequest(String sessionId, String postcode)
+            throws IOException, InterruptedException {
+
+        String privateApiEndpoint = this.clientConfigurationService.getPrivateApiEndpoint();
+        return sendHttpRequest(
                 requestBuilder(privateApiEndpoint, "postcode-lookup/" + postcode)
                         .header(SESSION_ID, sessionId)
                         .GET()

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -82,6 +82,15 @@ public class AddressSteps {
                         URLEncoder.encode(postcode.trim(), StandardCharsets.UTF_8)));
     }
 
+    @When("the user performs a GET postcode lookup for post code {string}")
+    public void theUserPerformsAGETPostcodeLookupForPostCode(String postcode)
+            throws IOException, InterruptedException {
+        this.testContext.setResponse(
+                this.addressApiClient.sendPostCodeLookUpGETRequest(
+                        this.testContext.getSessionId(),
+                        URLEncoder.encode(postcode.trim(), StandardCharsets.UTF_8)));
+    }
+
     @Then("user receives a list of addresses containing {string}")
     public void userReceivesAListOfAddressesContaining(String postcode) throws IOException {
         JsonNode jsonNode = objectMapper.readTree(this.testContext.getResponse().body());

--- a/integration-tests/src/test/resources/features/PostcodeLookupGetRequest.feature
+++ b/integration-tests/src/test/resources/features/PostcodeLookupGetRequest.feature
@@ -1,0 +1,33 @@
+Feature: Invalid postcode test
+
+  @postcode_lookup_GET_test
+  Scenario Outline: Postcode GET lookup
+    Given user has the test-identity <testUserDataSheetRowNumber> in the form of a signed JWT string
+
+    # Session
+    When user sends a POST request to session end point
+    Then user gets a session-id
+
+    # Postcode lookup
+    When the user performs a postcode lookup for post code "<testPostCode>"
+    Then user receives a list of addresses containing "<testPostCode>"
+
+    Examples:
+      | testUserDataSheetRowNumber | testPostCode |
+      | 197                        | SW1A 2AA     |
+
+  @invalid_postcode_GET_test
+  Scenario Outline: Invalid postcode GET lookup
+    Given user has the test-identity <testUserDataSheetRowNumber> in the form of a signed JWT string
+
+    # Session
+    When user sends a POST request to session end point
+    Then user gets a session-id
+
+    # Postcode lookup
+    When the user performs a postcode lookup for post code "<testPostCode>"
+    Then user does not get any address
+
+    Examples:
+      | testUserDataSheetRowNumber | testPostCode |
+      | 197                        | XX12 12XX    |


### PR DESCRIPTION
## Proposed changes

### What changed

**Added POST `/postcode-lookup` endpoint.**

Body example: `{ "postcode": "AA11 1AA" }`

- To change the postcode-lookup endpoint to be a POST request with a body instead of a GET request with the postcode PII in the URL (issues with logging) I have updated the APIGW and existing PostcodeLookup lambda to handle both GET and POST requests.

- Refactored lambda unit tests to include tests for both POST and GET. When GET is removed these tests will need removing and only the POST ones need to remain. The majority of tests only include POST requests.

- Updated the existing integration tests to now use the POST postcode-lookup endpoint. (Note: To ensure GET postcode-lookup endpoint is still tested, added a new feature file which can easily be deleted when GET endpoint is removed)

### Why did it change

We want to create a new private endpoint that our FE can use for searching postcodes, that does not include the users postcode in the URL as this can cause PII issues within logs.

Although this would traditionally be a GET request, the issue with PII in url and how that logs in so many places we decided it needed to be removed from the URL. Of the options, we decided a POST request with the postcode in the body had the best balance of ease of implementation and meeting our requirement.

### Issue tracking
- [OJ-3037](https://govukverify.atlassian.net/browse/OJ-3037)

### Screenshot logs
![image](https://github.com/user-attachments/assets/3dcf0b93-f729-4af5-9709-53c15a0ded9e)
![image](https://github.com/user-attachments/assets/bd3974b4-c568-4cd3-98cd-8837434c636d)

[OJ-3037]: https://govukverify.atlassian.net/browse/OJ-3037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ