### PR TITLE
OJ-3039: Revert "OJ-3033: Adjust regex"

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -292,7 +292,7 @@ Resources:
         Configuration:
           CustomDataIdentifier:
             - Name: postcode
-              Regex: "/(localdev|integration|production)\\/postcode-lookup\\/[a-zA-Z0-9%+]+"
+              Regex: "/(integration|production)\\/postcode-lookup\\/.*"
 
 
   PrivateAddressApiAccessLogGroupSubscriptionFilterCSLS:


### PR DESCRIPTION
Reverts govuk-one-login/ipv-cri-address-api#1193

as part of https://govukverify.atlassian.net/browse/OJ-3039
