### PR TITLE
OJ-3014: Add OTEL to PostcodeLookupHandler

### DIFF
--- a/lambdas/postcode-lookup/build.gradle
+++ b/lambdas/postcode-lookup/build.gradle
@@ -5,6 +5,8 @@ plugins {
 }
 
 dependencies {
+	implementation configurations.otel
+
 	implementation project(":lib"),
 			configurations.cri_common_lib,
 			configurations.aws,

--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.ErrorObject;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.instrumentation.httpclient.JavaHttpClientTelemetry;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import software.amazon.lambda.powertools.logging.CorrelationIdPathConstants;
@@ -82,10 +84,14 @@ public class PostcodeLookupHandler
                         clientProviderFactory.getSecretsProvider());
 
         HttpClient httpClient =
-                HttpClient.newBuilder()
-                        .version(HttpClient.Version.HTTP_2)
-                        .connectTimeout(Duration.ofSeconds(CONNECTION_TIMEOUT_SECONDS))
-                        .build();
+                JavaHttpClientTelemetry.builder(GlobalOpenTelemetry.get())
+                        .build()
+                        .newHttpClient(
+                                HttpClient.newBuilder()
+                                        .version(HttpClient.Version.HTTP_2)
+                                        .connectTimeout(
+                                                Duration.ofSeconds(CONNECTION_TIMEOUT_SECONDS))
+                                        .build());
 
         this.eventProbe = new EventProbe();
 


### PR DESCRIPTION
## Proposed changes

### What changed

Added OpenTelemetery to Postcode Lookup Lambdas.

### Why did it change

Now the /postcode-lookup endpoint is not invoked by a URL containing the postcode (PII). We can re-enable OTEL on this lambda/endpoint.

This adds instrumentation to Postcode Lookup Java Lambda so that we can see more details traces in dynatrace.

Previously reverted in: https://github.com/govuk-one-login/ipv-cri-address-api/pull/1185
Other Java Lambdas OpenTelemetry added in this PR: https://github.com/govuk-one-login/ipv-cri-address-api/pull/1194

### Issue tracking

- [OJ-3014](https://govukverify.atlassian.net/browse/OJ-3014)

### Screenshot

![image](https://github.com/user-attachments/assets/46ebd2ed-b45e-4d28-bf56-11eb6662ee81)

[OJ-3014]: https://govukverify.atlassian.net/browse/OJ-3014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ