### PR TITLE
OJ-3039: Remove data redaction policy

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -272,28 +272,6 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PrivateAddressApi}-private-AccessLogs
       RetentionInDays: 30
-      DataProtectionPolicy:
-        Name: uk_postcode_data_protection_policy
-        Description: ""
-        Version: "2021-06-01"
-        Statement:
-          - Sid: audit-policy
-            DataIdentifier:
-              - postcode
-            Operation:
-              Audit:
-                FindingsDestination: { }
-          - Sid: redact-policy
-            DataIdentifier:
-              - postcode
-            Operation:
-              Deidentify:
-                MaskConfig: { }
-        Configuration:
-          CustomDataIdentifier:
-            - Name: postcode
-              Regex: "/(integration|production)\\/postcode-lookup\\/.*"
-
 
   PrivateAddressApiAccessLogGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
### What changed

see: https://github.com/govuk-one-login/ipv-cri-address-api/pull/1199

Removed the the GET /postcode-lookup/{postcode} endpoint since the POST equivalent is now being used by see https://github.com/govuk-one-login/ipv-cri-address-front/pull/1091 we no longer need to redact.

### Why did it change

We've re-implemented the get endpoint as post to
migitated having to redaction postcode-lookup urls

- [OJ-3039](https://govukverify.atlassian.net/browse/OJ-3039)


[OJ-3039]: https://govukverify.atlassian.net/browse/OJ-3039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ