### PR TITLE
OJ-3044: PII postcode look function

### DIFF
--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/handler/PostcodeLookupHandler.java
@@ -65,7 +65,6 @@ public class PostcodeLookupHandler
     private final SessionService sessionService;
     private final EventProbe eventProbe;
     private final AuditService auditService;
-    private static final ObjectMapper objectMapper = new ObjectMapper();
     protected static final String SESSION_ID = "session_id";
     protected static final String LAMBDA_NAME = "postcode_lookup";
     protected static final String POSTCODE_ERROR = "postcode_lookup_error";
@@ -73,6 +72,7 @@ public class PostcodeLookupHandler
     protected static final String POSTCODE_ERROR_MESSAGE = "postcode_lookup_error_message";
 
     public static final long CONNECTION_TIMEOUT_SECONDS = 15;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @ExcludeFromGeneratedCoverageReport
     public PostcodeLookupHandler() {
@@ -97,7 +97,11 @@ public class PostcodeLookupHandler
 
         this.postcodeLookupService =
                 new PostcodeLookupService(
-                        configurationService, httpClient, LogManager.getLogger(), eventProbe);
+                        configurationService,
+                        httpClient,
+                        LogManager.getLogger(),
+                        eventProbe,
+                        OBJECT_MAPPER);
 
         this.sessionService =
                 new SessionService(
@@ -107,7 +111,7 @@ public class PostcodeLookupHandler
                 new AuditService(
                         clientProviderFactory.getSqsClient(),
                         configurationService,
-                        objectMapper,
+                        OBJECT_MAPPER,
                         new AuditEventFactory(configurationService, Clock.systemDefaultZone()));
     }
 
@@ -167,7 +171,7 @@ public class PostcodeLookupHandler
     private String getPostcodeFromRequest(APIGatewayProxyRequestEvent input)
             throws PostcodeLookupBadRequestException {
         try {
-            Postcode postcode = objectMapper.readValue(input.getBody(), Postcode.class);
+            Postcode postcode = OBJECT_MAPPER.readValue(input.getBody(), Postcode.class);
 
             if (postcode != null && postcode.getValue() != null) {
                 return postcode.getValue();

--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/pii/PiiPostcodeMasker.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/pii/PiiPostcodeMasker.java
@@ -1,0 +1,20 @@
+package uk.gov.di.ipv.cri.address.api.pii;
+
+import java.util.regex.Pattern;
+
+public class PiiPostcodeMasker {
+    private static final Pattern POSTCODE_PATTERN =
+            Pattern.compile(
+                    "\\b[0-9A-Z]{1,4}\\d[A-Z\\d]?\\s?\\d[A-Z]{2}\\b|\\b[0-9A-Z]{3,8}\\b\n",
+                    Pattern.CASE_INSENSITIVE);
+
+    private PiiPostcodeMasker() {
+        throw new IllegalStateException("This class is not meant to be instantiated");
+    }
+
+    public static String sanitize(String value) {
+        return POSTCODE_PATTERN
+                .matcher(value == null ? "" : value)
+                .replaceAll(match -> "*".repeat(match.group().length()));
+    }
+}

--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupService.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupService.java
@@ -15,6 +15,7 @@ import uk.gov.di.ipv.cri.address.api.models.Dpa;
 import uk.gov.di.ipv.cri.address.api.models.OrdnanceSurveyPostcodeError;
 import uk.gov.di.ipv.cri.address.api.models.OrdnanceSurveyPostcodeResponse;
 import uk.gov.di.ipv.cri.address.api.models.Result;
+import uk.gov.di.ipv.cri.address.api.pii.PiiPostcodeMasker;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventContext;
 import uk.gov.di.ipv.cri.common.library.domain.personidentity.Address;
 import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
@@ -179,20 +180,24 @@ public class PostcodeLookupService {
         try {
             OrdnanceSurveyPostcodeError error =
                     objectMapper.readValue(response, OrdnanceSurveyPostcodeError.class);
+            String sanitizedMessage = PiiPostcodeMasker.sanitize(error.getError().getMessage());
             log.error(
                     "{} status {}: {}",
                     LOG_RESPONSE_PREFIX,
                     error.getError().getStatuscode(),
-                    error.getError().getMessage());
+                    sanitizedMessage);
             throw new PostcodeLookupProcessingException(
                     LOG_RESPONSE_PREFIX
                             + error.getError().getStatuscode()
                             + ": "
-                            + error.getError().getMessage());
+                            + sanitizedMessage);
         } catch (Exception e) {
-            log.error("{}unknown error: {}", LOG_RESPONSE_PREFIX, response);
+            log.error(
+                    "{}unknown error: {}",
+                    LOG_RESPONSE_PREFIX,
+                    PiiPostcodeMasker.sanitize(response));
             throw new PostcodeLookupProcessingException(
-                    "Error processing postcode lookup: " + response);
+                    "Error processing postcode lookup: " + PiiPostcodeMasker.sanitize(response));
         }
     }
 
@@ -200,13 +205,17 @@ public class PostcodeLookupService {
         try {
             OrdnanceSurveyPostcodeError error =
                     objectMapper.readValue(response, OrdnanceSurveyPostcodeError.class);
+            String sanitizedMessage = PiiPostcodeMasker.sanitize(error.getError().getMessage());
             log.error(
                     "{} status {}: {}",
                     LOG_RESPONSE_PREFIX,
                     error.getError().getStatuscode(),
-                    error.getError().getMessage());
+                    sanitizedMessage);
         } catch (Exception e) {
-            log.error("{} unknown error: {}", LOG_RESPONSE_PREFIX, response);
+            log.error(
+                    "{} unknown error: {}",
+                    LOG_RESPONSE_PREFIX,
+                    PiiPostcodeMasker.sanitize(response));
         }
         return Collections.emptyList();
     }

--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupService.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupService.java
@@ -56,7 +56,7 @@ public class PostcodeLookupService {
     // Create our http client to enable asynchronous requests
     private final HttpClient client;
     private final Logger log;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
     private final ConfigurationService configurationService;
     private final EventProbe eventProbe;
 
@@ -64,11 +64,13 @@ public class PostcodeLookupService {
             ConfigurationService configurationService,
             HttpClient client,
             Logger log,
-            EventProbe eventProbe) {
+            EventProbe eventProbe,
+            ObjectMapper objectMapper) {
         this.configurationService = configurationService;
         this.client = client;
         this.log = log;
         this.eventProbe = eventProbe;
+        this.objectMapper = objectMapper;
     }
 
     public List<CanonicalAddress> lookupPostcode(String postcode)

--- a/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/pii/PiiPostcodeMaskerTest.java
+++ b/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/pii/PiiPostcodeMaskerTest.java
@@ -1,0 +1,62 @@
+package uk.gov.di.ipv.cri.address.api.pii;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PiiPostcodeMaskerTest {
+    @Test
+    void validPostcodeCanBeMasked() {
+        assertEquals("********", PiiPostcodeMasker.sanitize("SW1A 1AA"));
+        assertEquals("********", PiiPostcodeMasker.sanitize("EC1A 1BB"));
+        assertEquals("*******", PiiPostcodeMasker.sanitize("W1A 0AX"));
+    }
+
+    @Test
+    void postcodeInSentenceCanBeMasked() {
+        assertEquals(
+                "My address is ********", PiiPostcodeMasker.sanitize("My address is SW1A 1AA"));
+        assertEquals("******** is in London", PiiPostcodeMasker.sanitize("EC1A 1BB is in London"));
+    }
+
+    @Test
+    void multiplePostcodesInSentenceCanBeMasked() {
+        assertEquals(
+                "******* and ******** are valid postcodes",
+                PiiPostcodeMasker.sanitize("W1A 0AX and SW1A 2AA are valid postcodes"));
+    }
+
+    @Test
+    void nullInputReturnsEmptyString() {
+        assertEquals("", PiiPostcodeMasker.sanitize(null));
+    }
+
+    @Test
+    void emptyStringReturnsEmptyString() {
+        assertEquals("", PiiPostcodeMasker.sanitize(""));
+    }
+
+    @Test
+    void noPostcodeInSentenceReturnsSentenceWithoutAnyMasking() {
+        assertEquals(
+                "This is just a normal sentence.",
+                PiiPostcodeMasker.sanitize("This is just a normal sentence."));
+    }
+
+    @Test
+    void lowerCasePostcodeCanBeMasked() {
+        assertEquals("********", PiiPostcodeMasker.sanitize("sw1a 1aa"));
+    }
+
+    @Test
+    void postcodeWithExtraSpacesCanBeMasked() {
+        assertEquals("   ********   ", PiiPostcodeMasker.sanitize("   SW1A 1AA   "));
+    }
+
+    @Test
+    void postcodeLikeValueCanBeMasked() {
+        assertEquals(
+                "Requested postcode was *******",
+                PiiPostcodeMasker.sanitize("Requested postcode was 5WF12LZ"));
+    }
+}

--- a/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
+++ b/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
@@ -1,6 +1,8 @@
 package uk.gov.di.ipv.cri.address.api.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -10,7 +12,6 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -56,7 +57,17 @@ class PostcodeLookupServiceTest {
     @Mock private Logger log;
     @Mock private EventProbe eventProbe;
     @Captor private ArgumentCaptor<HttpRequest> postCodeRequest;
-    @InjectMocks private PostcodeLookupService postcodeLookupService;
+    private PostcodeLookupService postcodeLookupService;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        this.objectMapper = new ObjectMapper();
+
+        postcodeLookupService =
+                new PostcodeLookupService(
+                        mockConfigurationService, httpClient, log, eventProbe, objectMapper);
+    }
 
     @Test
     void shouldLogAPILatency() throws IOException, InterruptedException {


### PR DESCRIPTION
## Proposed changes

In some cases a postcode request to OS Places API, results in a response where the API was unable to find a record for a
request and it tries to be helpful by suggesting there was an issue with the postcode value used to make the request. These values maybe close to actual postcode values for instance user may have enter a 5 instead of an S. This PR mask the postcode values found in such responses

### What changed

Postcode like values are seen in responses to bad request

### Why did it change

The program considers postcode as PII, this PR mask any cases of these values

- [OJ-3044](https://govukverify.atlassian.net/browse/OJ-3044)


[OJ-3044]: https://govukverify.atlassian.net/browse/OJ-3044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ