### PR TITLE
feat: use kms client from ClientProviderFactory in IssueCredentialHandler

### DIFF
--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -14,7 +14,8 @@ dependencies {
 			configurations.nimbus,
 			configurations.dynamodb,
 			configurations.jackson,
-			configurations.sqs
+			configurations.sqs,
+			configurations.kms
 
 	aspect configurations.powertools
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
@@ -99,7 +99,10 @@ public class IssueCredentialHandler
 
         String kmsSigningKeyId =
                 config.getCommonParameterValue("verifiableCredentialKmsSigningKeyId");
-        SignedJWTFactory signedJWTFactory = new SignedJWTFactory(new KMSSigner(kmsSigningKeyId));
+
+        SignedJWTFactory signedJWTFactory =
+                new SignedJWTFactory(
+                        new KMSSigner(kmsSigningKeyId, clientProviderFactory.getKMSClient()));
 
         this.verifiableCredentialService =
                 new VerifiableCredentialService(


### PR DESCRIPTION
## Proposed changes

### What changed
KMSClient is being referenced from the ServiceFactory instead of manually creating it.

### Why did it change
To support SnapStart, we have to handle credentials differently. The ServiceFactory is a wrapper over ClientProviderFactory which is provided from ipv-cri-lib. The ClientProviderFactory gives us a SnapStart suitable reference of the KMSClient that we can use.

### Issue tracking
- [OJ-3055](https://govukverify.atlassian.net/browse/OJ-3055)



[OJ-3055]: https://govukverify.atlassian.net/browse/OJ-3055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ