### PR TITLE
OJ-3068: Upgrade lambda node runtime to 22

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: prettier
         types_or: ["javascript", "ts", "json"]
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v0.83.5
+    rev: v1.27.0
     hooks:
       - id: cfn-lint
         files: .template\.ya?ml$

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -514,7 +514,7 @@ Resources:
           - [!Ref GetAddressesFunctionCanaryErrors, !Ref GetAddressesFunctionCanary5xxErrors]
           - [!Ref AWS::NoValue]
       CodeUri: ../../lambdas/get-addresses/
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       Layers:
         - !Sub
           - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"


### PR DESCRIPTION
## Proposed changes

### What changed

- Upgrade node runtime from 18 -> 22 for the Addresses Lambda. 
- Bump to cfn-lint in the pre-commit config to support node 22 being a valid runtime.

### Why did it change

Node 18 has reached end of active live support 

### Issue tracking

- [OJ-3068](https://govukverify.atlassian.net/browse/OJ-3068)


[OJ-3068]: https://govukverify.atlassian.net/browse/OJ-3068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ