### PR TITLE
OJ-3068: Remove Setup SAM step

### DIFF
--- a/.github/workflows/package-for-build.yml
+++ b/.github/workflows/package-for-build.yml
@@ -30,11 +30,6 @@ jobs:
         with:
           python-version: 3.11.2
 
-      - name: Setup SAM
-        uses: aws-actions/setup-sam@v2
-        with:
-          version: 1.74.0
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:

--- a/.github/workflows/package-for-dev.yml
+++ b/.github/workflows/package-for-dev.yml
@@ -30,11 +30,6 @@ jobs:
         with:
           python-version: 3.11.2
 
-      - name: Setup SAM
-        uses: aws-actions/setup-sam@v2
-        with:
-          version: 1.74.0
-
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:


### PR DESCRIPTION
## Proposed changes

### What changed

Remove `Setup SAM` step from the post merge deploy dev & build GHA. 

### Why did it change

SAM CLI 1.132.0+ is needed to support node 22 runtimes. `unbuntu-latest` image already comes with SAM CLI installed (and is a much newer version)

### Issue tracking
- [OJ-3068](https://govukverify.atlassian.net/browse/OJ-3068)


[OJ-3068]: https://govukverify.atlassian.net/browse/OJ-3068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ