### PR TITLE
OJ-3053: update - set provision concurrency to 0 for build

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -163,7 +163,7 @@ Mappings:
       provisionedConcurrency: 0
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     build:
-      provisionedConcurrency: 1
+      provisionedConcurrency: 0
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     staging:
       provisionedConcurrency: 0

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -485,6 +485,8 @@ Resources:
   GetAddressesFunction:
     Type: AWS::Serverless::Function
     Properties:
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 1
       Handler: get-addresses-handler.lambdaHandler
       DeploymentPreference:
         Alarms: !If


### PR DESCRIPTION
## Proposed changes

### What changed

- Set provision concurrency to 0 in build
- Added provision concurrency only to `GetAddressesFunction` typescript lambda

### Why did it change

As provisioned concurrency does not work alongside SnapStart. 

### Issue tracking

- [OJ-3053](https://govukverify.atlassian.net/browse/OJ-3053)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3053]: https://govukverify.atlassian.net/browse/OJ-3053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ