### PR TITLE
OJ-2821: Bump cri-lib and re-enable Address5xx Canary

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		mockito                  : "4.3.1",
 		glassfish_version        : "3.0.3",
 		powertools_version       : "1.18.0",
-		cri_common_lib           : "4.0.0",
+		cri_common_lib           : "4.1.0",
 		pact_provider_version	 : "4.5.11",
 		webcompere_version       : "2.1.6",
 		slf4j_log4j12_version    : "2.0.13", // For contract test debug

--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -46,7 +46,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-      x-amazon-apigateway-request-validator: "Validate body" ## todo this validator doesn't exist
+      x-amazon-apigateway-request-validator: "Validate both"
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -367,9 +367,8 @@ Resources:
       DeploymentPreference:
         Alarms: !If
           - UseCanaryDeploymentAlarms
-          - [!Ref AddressFunctionCanaryErrors]
+          - [!Ref AddressFunctionCanaryErrors, !Ref AddressFunctionCanary5xxErrors]
           - [!Ref AWS::NoValue]
-          #- !Ref AddressFunctionCanary5xxErrors
       Layers:
         - !Sub
           - "{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}"
@@ -824,35 +823,34 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       TreatMissingData: notBreaching
 
-  ### Alarm temporarily disabled to avoid false positives and a rollback during deployment
-  # AddressFunctionCanary5xxErrors:
-  #   Type: AWS::CloudWatch::Alarm
-  #   Condition: UseCanaryDeploymentAlarms
-  #   Properties:
-  #     ActionsEnabled: true
-  #     AlarmActions:
-  #       - !ImportValue platform-alarm-warning-alert-topic
-  #     OKActions:
-  #       - !ImportValue platform-alarm-warning-alert-topic
-  #     AlarmDescription: !Sub "AddressFunction Lambda returning 5xx response."
-  #     Namespace: AWS/ApiGateway
-  #     MetricName: 5XXError
-  #     Dimensions:
-  #       - Name: ApiName
-  #         Value: !Sub "${AWS::StackName}-PrivateAddressApi"
-  #       - Name: Method
-  #         Value: PUT
-  #       - Name: Stage
-  #         Value: !Ref Environment
-  #       - Name: Resource
-  #         Value: /address
-  #     Statistic: Sum
-  #     Unit: Count
-  #     Period: 60
-  #     EvaluationPeriods: 1
-  #     Threshold: 1
-  #     ComparisonOperator: GreaterThanOrEqualToThreshold
-  #     TreatMissingData: notBreaching
+  AddressFunctionCanary5xxErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeploymentAlarms
+    Properties:
+     ActionsEnabled: true
+     AlarmActions:
+       - !ImportValue platform-alarm-warning-alert-topic
+     OKActions:
+       - !ImportValue platform-alarm-warning-alert-topic
+     AlarmDescription: !Sub "AddressFunction Lambda returning 5xx response."
+     Namespace: AWS/ApiGateway
+     MetricName: 5XXError
+     Dimensions:
+       - Name: ApiName
+         Value: !Sub "${AWS::StackName}-PrivateAddressApi"
+       - Name: Method
+         Value: PUT
+       - Name: Stage
+         Value: !Ref Environment
+       - Name: Resource
+         Value: /address
+     Statistic: Sum
+     Unit: Count
+     Period: 60
+     EvaluationPeriods: 1
+     Threshold: 1
+     ComparisonOperator: GreaterThanOrEqualToThreshold
+     TreatMissingData: notBreaching
 
   GetAddressesFunctionCanaryErrors:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## Proposed changes

### What changed

- Bump cri-lib to 4.1.0 to include the new validateSession logic
- Re-enable `AddressFunctionCanary5xxErrors`
- Set `x-amazon-apigateway-request-validator` to `Validate both` so requests without the `session_id` header return a 400.

### Why did it change

You can get through to the confirm page on a UK journey without a session, this should be handled separately, but we still want to handle this and return a 4XX error instead of a 5XX.

cri-lib `v4.1.0` contains new logic to handle `validateSession` being passed an 'empty' String. Instead of a `DynamoDBException` being returned which is not handled, a `SessionNotFoundException` will be returned.

### Issue tracking
- [OJ-2821](https://govukverify.atlassian.net/browse/OJ-2821)

[OJ-2821]: https://govukverify.atlassian.net/browse/OJ-2821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ