### PR TITLE
OJ-3058: feat - enable snap start to production

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -285,10 +285,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       SnapStart:
-        ApplyOn: !If
-          - IsProdEnvironment
-          - None
-          - PublishedVersions
+        ApplyOn: PublishedVersions
       CodeUri: ../../lambdas/postcode-lookup
       Handler: uk.gov.di.ipv.cri.address.api.handler.PostcodeLookupHandler::handleRequest
       DeploymentPreference:
@@ -368,10 +365,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       SnapStart:
-        ApplyOn: !If
-          - IsProdEnvironment
-          - None
-          - PublishedVersions
+        ApplyOn: PublishedVersions
       CodeUri: ../../lambdas/address
       Handler: uk.gov.di.ipv.cri.address.api.handler.AddressHandler::handleRequest
       DeploymentPreference:
@@ -427,10 +421,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       SnapStart:
-        ApplyOn: !If
-          - IsProdEnvironment
-          - None
-          - PublishedVersions
+        ApplyOn: PublishedVersions
       Handler: uk.gov.di.ipv.cri.address.api.handler.IssueCredentialHandler::handleRequest
       DeploymentPreference:
         Alarms: !If


### PR DESCRIPTION

## Proposed changes

### What changed

- Removed condition to disable to snapstart for production

### Why did it change

To enable snapstart for production.

### Issue tracking

- [OJ-3058](https://govukverify.atlassian.net/browse/OJ-3058)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3058]: https://govukverify.atlassian.net/browse/OJ-3058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ