### PR TITLE
OJ-3058: update - remove provision concurrency in prod

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -172,7 +172,7 @@ Mappings:
       provisionedConcurrency: 0
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
     production:
-      provisionedConcurrency: 1
+      provisionedConcurrency: 0
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
 
   MaxJwtTtlMapping:


### PR DESCRIPTION

## Proposed changes

### What changed

- Set provision concurrency in Prod to 0

### Why did it change

- To enable snap start to be configured in Prod

### Issue tracking

- [OJ-3058](https://govukverify.atlassian.net/browse/OJ-3058)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3058]: https://govukverify.atlassian.net/browse/OJ-3058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ