### PR TITLE
OJ-3124: Remove use of deprecated DataStore.getClient method

### DIFF
--- a/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
+++ b/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
@@ -70,7 +70,11 @@ public class AddressHandler
         this.sessionService =
                 new SessionService(
                         configurationService, clientProviderFactory.getDynamoDbEnhancedClient());
-        this.addressService = new AddressService(configurationService, objectMapper);
+        this.addressService =
+                new AddressService(
+                        configurationService,
+                        objectMapper,
+                        clientProviderFactory.getDynamoDbEnhancedClient());
         this.eventProbe = new EventProbe();
     }
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/handler/IssueCredentialHandler.java
@@ -111,7 +111,9 @@ public class IssueCredentialHandler
                         getMapperWithCustomSerializers(),
                         new VerifiableCredentialClaimsSetBuilder(config, Clock.systemUTC()));
 
-        this.addressService = new AddressService(config, objectMapper);
+        this.addressService =
+                new AddressService(
+                        config, objectMapper, clientProviderFactory.getDynamoDbEnhancedClient());
         this.sessionService =
                 new SessionService(config, clientProviderFactory.getDynamoDbEnhancedClient());
         this.eventProbe = new EventProbe();

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.utils.StringUtils;
 import uk.gov.di.ipv.cri.address.library.exception.AddressProcessingException;
 import uk.gov.di.ipv.cri.address.library.persistence.item.AddressItem;
@@ -40,12 +41,15 @@ public class AddressService {
     private ObjectReader addressReader;
 
     @ExcludeFromGeneratedCoverageReport
-    public AddressService(ConfigurationService configurationService, ObjectMapper objectMapper) {
+    public AddressService(
+            ConfigurationService configurationService,
+            ObjectMapper objectMapper,
+            DynamoDbEnhancedClient dynamoDbEnhancedClient) {
         this(
                 new DataStore<>(
                         configurationService.getParameterValue("AddressTableName"),
                         AddressItem.class,
-                        DataStore.getClient()),
+                        dynamoDbEnhancedClient),
                 objectMapper);
     }
 
@@ -76,6 +80,8 @@ public class AddressService {
         addressItem.setExpiryDate(ttlExpiryEpoch);
         addressItem.setAddresses(addresses);
         dataStore.create(addressItem);
+
+        LOGGER.info("Saved address");
 
         return addressItem;
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Remove use of deprecated DataStore.getClient method

### Why did it change

When investigating 502 errors in production we noticed that the way AddressService sets up EnhancedDynamoDbClient is different to SessionService and could be causing issues now that we have snapstart enabled

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3124](https://govukverify.atlassian.net/browse/OJ-3124)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


[OJ-3124]: https://govukverify.atlassian.net/browse/OJ-3124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ