### PR TITLE
OJ-3124: Get addressTtl from configurationService

### DIFF
--- a/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
+++ b/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
@@ -17,6 +17,7 @@ import uk.gov.di.ipv.cri.common.library.exception.SessionExpiredException;
 import uk.gov.di.ipv.cri.common.library.exception.SessionNotFoundException;
 import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
 import uk.gov.di.ipv.cri.common.library.persistence.item.SessionItem;
+import uk.gov.di.ipv.cri.common.library.service.ConfigurationService;
 import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 
@@ -41,6 +42,7 @@ class AddressHandlerTest {
 
     @Mock private SessionService mockSessionService;
     @Mock private AddressService mockAddressService;
+    @Mock private ConfigurationService mockConfigurationService;
 
     @Mock private APIGatewayProxyRequestEvent apiGatewayProxyRequestEvent;
 
@@ -50,7 +52,12 @@ class AddressHandlerTest {
 
     @BeforeEach
     void setUp() {
-        addressHandler = new AddressHandler(mockSessionService, mockAddressService, eventProbe);
+        addressHandler =
+                new AddressHandler(
+                        mockSessionService,
+                        mockAddressService,
+                        eventProbe,
+                        mockConfigurationService);
     }
 
     @Test

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
@@ -82,7 +82,7 @@ public class AddressService {
         dataStore.create(addressItem);
 
         LOGGER.info(
-                "Saved address with TTL:{} and length: {}",
+                "Saved address with TTL: {} and length: {}",
                 ttlExpiryEpoch,
                 addressItem.getAddresses().size());
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Get addressTtl from configurationService and remove hardcoding

### Why did it change

The hard coding was just to test the theory that the NullPointerExceptions were being caused by a dodgy TTL. 

Now that we have confirmed this is the case, we can remove the hard coding and use the service as originally suggested, but with the variable defined at a scope that means it will not be saved in the snapshots for snapstart.

### Screenshots

<img width="1474" alt="image" src="https://github.com/user-attachments/assets/d42e853e-1714-48d7-af98-bd9cd72d1d5b" />
<img width="660" alt="image" src="https://github.com/user-attachments/assets/7883ae8e-88bb-4efb-b90f-e8ddb2ac7023" />

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3124](https://govukverify.atlassian.net/browse/OJ-3124)


[OJ-3124]: https://govukverify.atlassian.net/browse/OJ-3124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ