### PR TITLE
OJ-3108: Fix Scan repo on schedule erroring

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -14,6 +14,8 @@ jobs:
   unit-tests-ts:
     name: Unit tests
     uses: ./.github/workflows/run-unit-tests-ts.yml
+    with:
+      coverage-report: true
 
   unit-tests-java:
     name: Unit tests

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -1,6 +1,7 @@
 name: Scan repository
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [main]
@@ -16,7 +17,8 @@ permissions: read-all
 
 jobs:
   unit-tests-ts:
-    name: Test coverage
+    name: Collect coverage
+    if: ${{ github.event_name != 'pull_request' }}
     uses: ./.github/workflows/run-unit-tests-ts.yml
     with:
       coverage-report: true
@@ -81,15 +83,17 @@ jobs:
     name: SonarCloud / TypeScript
     needs: unit-tests-ts
     runs-on: ubuntu-latest
+    if: ${{ success() || needs.unit-tests-ts.result == 'skipped' }}
     steps:
       - name: Run SonarCloud scan
         uses: govuk-one-login/github-actions/code-quality/sonarcloud@5480cced560e896dea12c47ea33e548a4d093e65
         with:
           projectBaseDir: lambdas/get-addresses
           coverage-location: lambdas/get-addresses/coverage
-          coverage-artifact: ${{ needs.unit-tests-ts.outputs.coverage-artifact }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           sonar-token: ${{ secrets.SONAR_TOKEN_TS }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          coverage-artifact: ${{ needs.unit-tests-ts.outputs.coverage-artifact || 'coverage-ts' }}
+          coverage-run-id: ${{ github.event_name != 'pull_request' && github.run_id || null }}
 
   codeql:
     name: CodeQL


### PR DESCRIPTION
## Proposed changes

### What changed

- Scan repo workflow no longer runs TypeScript unit tests on pull requests (unit tests were ran twice on each PR). The coverage-ts artefact is now used from the `Check PR` workflow.
- `coverage-run-id` is passed into the TypeScript `SonarCloud` action for none PRs so it does not run the `Await coverage report` step.
- Added workflow_dispatch to Scan Repo action. 

### Why did it change

TypeScript Unit tests were running twice on every PR. 

`Await coverage report` was added to the TypeScript sonarcloud github action which broke our Scan Repo action when running on a schedule. Passing in the workflow id to the action prevents this from happening. 

### Issue tracking

- [OJ-3108](https://govukverify.atlassian.net/browse/OJ-3108)

[OJ-3108]: https://govukverify.atlassian.net/browse/OJ-3108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ