### PR TITLE
Oj 3135 address-api-add unhappy path

### DIFF
--- a/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
@@ -161,7 +161,7 @@ public class AddressApiClient {
         return sendHttpRequest(requestBuilder(privateApiEndpoint, "addresses/v2").GET().build());
     }
 
-    public HttpResponse<String> sendNoPostCodeNoSessionIdLookUpRequest(String postcode)
+    public HttpResponse<String> sendPostCodeLookupRequestWithNoSessionId(String postcode)
             throws IOException, InterruptedException {
 
         String privateApiEndpoint = this.clientConfigurationService.getPrivateApiEndpoint();

--- a/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
@@ -22,6 +22,7 @@ public class AddressApiClient {
     private final ObjectMapper objectMapper;
     private static final String JSON_MIME_MEDIA_TYPE = "application/json";
 
+
     public AddressApiClient(ClientConfigurationService clientConfigurationService) {
         this.clientConfigurationService = clientConfigurationService;
         this.httpClient = HttpClient.newBuilder().build();
@@ -153,4 +154,32 @@ public class AddressApiClient {
             throws IOException, InterruptedException {
         return this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
     }
+
+    public HttpResponse<String> sendGetAddressesLookupRequestWithOutSessionId()
+            throws IOException, InterruptedException {
+
+        String privateApiEndpoint = this.clientConfigurationService.getPrivateApiEndpoint();
+        System.out.println(clientConfigurationService.createUriPath("addresses/v2"));
+        System.out.println(privateApiEndpoint);
+        return sendHttpRequest(
+
+                requestBuilder(privateApiEndpoint, "addresses/v2")
+                        .GET()
+                        .build());
+
+    }
+
+
+    public HttpResponse<String> sendNoPostCodeLookUpRequest()
+            throws IOException, InterruptedException {
+
+        String privateApiEndpoint = this.clientConfigurationService.getPrivateApiEndpoint();
+        return sendHttpRequest(
+                requestBuilder(privateApiEndpoint, "postcode-lookup")
+
+                       // .header(SESSION_ID, sessionId)
+                        .POST(HttpRequest.BodyPublishers.noBody())
+                        .build());
+    }
+
 }

--- a/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
@@ -158,20 +158,30 @@ public class AddressApiClient {
             throws IOException, InterruptedException {
 
         String privateApiEndpoint = this.clientConfigurationService.getPrivateApiEndpoint();
-        System.out.println(clientConfigurationService.createUriPath("addresses/v2"));
-        System.out.println(privateApiEndpoint);
         return sendHttpRequest(requestBuilder(privateApiEndpoint, "addresses/v2").GET().build());
     }
 
-    public HttpResponse<String> sendNoPostCodeLookUpRequest()
+    public HttpResponse<String> sendNoPostCodeNoSessionIdLookUpRequest(String postcode)
             throws IOException, InterruptedException {
 
         String privateApiEndpoint = this.clientConfigurationService.getPrivateApiEndpoint();
         return sendHttpRequest(
                 requestBuilder(privateApiEndpoint, "postcode-lookup")
-
-                        // .header(SESSION_ID, sessionId)
-                        .POST(HttpRequest.BodyPublishers.noBody())
+                        .POST(
+                                HttpRequest.BodyPublishers.ofString(
+                                        "{\"postcode\": \"" + postcode + "\"}"))
                         .build());
     }
+    public HttpResponse<String> sendNoPostCodeWithSessionIdLookUpRequest(String sessionId)
+            throws IOException, InterruptedException {
+
+        String privateApiEndpoint = this.clientConfigurationService.getPrivateApiEndpoint();
+        return sendHttpRequest(
+                requestBuilder(privateApiEndpoint, "postcode-lookup")
+                        .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                        .header(SESSION_ID, sessionId)
+                        .build());
+
+    }
+
 }

--- a/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
@@ -22,7 +22,6 @@ public class AddressApiClient {
     private final ObjectMapper objectMapper;
     private static final String JSON_MIME_MEDIA_TYPE = "application/json";
 
-
     public AddressApiClient(ClientConfigurationService clientConfigurationService) {
         this.clientConfigurationService = clientConfigurationService;
         this.httpClient = HttpClient.newBuilder().build();
@@ -161,14 +160,8 @@ public class AddressApiClient {
         String privateApiEndpoint = this.clientConfigurationService.getPrivateApiEndpoint();
         System.out.println(clientConfigurationService.createUriPath("addresses/v2"));
         System.out.println(privateApiEndpoint);
-        return sendHttpRequest(
-
-                requestBuilder(privateApiEndpoint, "addresses/v2")
-                        .GET()
-                        .build());
-
+        return sendHttpRequest(requestBuilder(privateApiEndpoint, "addresses/v2").GET().build());
     }
-
 
     public HttpResponse<String> sendNoPostCodeLookUpRequest()
             throws IOException, InterruptedException {
@@ -177,9 +170,8 @@ public class AddressApiClient {
         return sendHttpRequest(
                 requestBuilder(privateApiEndpoint, "postcode-lookup")
 
-                       // .header(SESSION_ID, sessionId)
+                        // .header(SESSION_ID, sessionId)
                         .POST(HttpRequest.BodyPublishers.noBody())
                         .build());
     }
-
 }

--- a/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
@@ -172,6 +172,7 @@ public class AddressApiClient {
                                         "{\"postcode\": \"" + postcode + "\"}"))
                         .build());
     }
+
     public HttpResponse<String> sendNoPostCodeWithSessionIdLookUpRequest(String sessionId)
             throws IOException, InterruptedException {
 
@@ -181,7 +182,5 @@ public class AddressApiClient {
                         .POST(HttpRequest.BodyPublishers.ofString("{}"))
                         .header(SESSION_ID, sessionId)
                         .build());
-
     }
-
 }

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -402,7 +402,7 @@ public class AddressSteps {
     }
 
     @Then("the endpoint should return a 400 HTTP status code")
-    public void theEndpointShouldReturnA400HttpStatusCode() throws ParseException, IOException {
+    public void theEndpointShouldReturnA400HttpStatusCode() {
         assertEquals(400, this.testContext.getResponse().statusCode());
     }
 

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -13,6 +13,7 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.junit.jupiter.api.Assertions;
 import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
 import uk.gov.di.ipv.cri.common.library.domain.TestHarnessResponse;
@@ -412,7 +413,7 @@ public class AddressSteps {
             aRequestIsMadeToThePostcodeLookupEndpointWithPostcodeAndNoSessionIdInTheRequestBody()
                     throws IOException, InterruptedException {
         this.testContext.setResponse(
-                this.addressApiClient.sendNoPostCodeNoSessionIdLookUpRequest("TEST"));
+                this.addressApiClient.sendPostCodeLookupRequestWithNoSessionId("TEST"));
     }
 
     @Given(

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -13,7 +13,6 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import software.amazon.awssdk.awscore.util.SignerOverrideUtils;
 import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
 import uk.gov.di.ipv.cri.common.library.domain.TestHarnessResponse;
@@ -394,9 +393,10 @@ public class AddressSteps {
                 payload.at("/vc/credentialSubject/address/1/validFrom").asText());
     }
 
-    @Given("a request is made to the addresses endpoint and it does not include a session_id header")
+    @Given(
+            "a request is made to the addresses endpoint and it does not include a session_id header")
     public void aRequestIsMadeToTheAddressesEndpointWithoutSessionIdHeader()
-                    throws IOException, InterruptedException {
+            throws IOException, InterruptedException {
         this.testContext.setResponse(
                 this.addressApiClient.sendGetAddressesLookupRequestWithOutSessionId());
     }
@@ -405,27 +405,39 @@ public class AddressSteps {
     public void theEndpointShouldReturnA400HttpStatusCode() throws ParseException, IOException {
         assertEquals(400, this.testContext.getResponse().statusCode());
     }
-    @Given("a request is made to the postcode-lookup endpoint with postcode and no session id in the request body")
-    public void aRequestIsMadeToThePostcodeLookupEndpointWithPostcodeAndNoSessionIdInTheRequestBody()
+
+    @Given(
+            "a request is made to the postcode-lookup endpoint with postcode and no session id in the request body")
+    public void
+            aRequestIsMadeToThePostcodeLookupEndpointWithPostcodeAndNoSessionIdInTheRequestBody()
                     throws IOException, InterruptedException {
-        this.testContext.setResponse(this.addressApiClient.sendNoPostCodeNoSessionIdLookUpRequest("TEST"));
+        this.testContext.setResponse(
+                this.addressApiClient.sendNoPostCodeNoSessionIdLookUpRequest("TEST"));
     }
-    @Given("a request is made to the postcode-lookup endpoint without a postcode and with session id in the request body")
-    public void aRequestIsMadeToThePostcodeLookupEndpointWithoutPostcodeAndWithSessionIdInTheRequestBody()
-            throws IOException, InterruptedException {
-        this.testContext.setResponse(this.addressApiClient.sendNoPostCodeWithSessionIdLookUpRequest(this.testContext.getSessionId()));
+
+    @Given(
+            "a request is made to the postcode-lookup endpoint without a postcode and with session id in the request body")
+    public void
+            aRequestIsMadeToThePostcodeLookupEndpointWithoutPostcodeAndWithSessionIdInTheRequestBody()
+                    throws IOException, InterruptedException {
+        this.testContext.setResponse(
+                this.addressApiClient.sendNoPostCodeWithSessionIdLookUpRequest(
+                        this.testContext.getSessionId()));
     }
+
     @Then("the response body contains no session id error")
     public void theResponseBodyContainsNoSessionIdError() {
         var responseBody = this.testContext.getResponse().body();
         assertNotNull(responseBody);
-        assertEquals("{\"message\": \"Missing required request parameters: [session_id]\"}",responseBody );
+        assertEquals(
+                "{\"message\": \"Missing required request parameters: [session_id]\"}",
+                responseBody);
     }
+
     @Then("the response body contains no postcode error")
     public void theResponseBodyContainsNoPostcodeError() {
         var responseBody = this.testContext.getResponse().body();
         assertNotNull(responseBody);
-        assertEquals("\"Missing postcode in request body.\"",responseBody );
-
+        assertEquals("\"Missing postcode in request body.\"", responseBody);
     }
 }

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -407,9 +407,9 @@ public class AddressSteps {
     }
 
     @Given(
-            "a request is made to the postcode-lookup endpoint with postcode and no session id in the request body")
+            "a request is made to the postcode-lookup endpoint with postcode in the request body with no session id header")
     public void
-            aRequestIsMadeToThePostcodeLookupEndpointWithPostcodeAndNoSessionIdInTheRequestBody()
+            aRequestIsMadeToThePostcodeLookupEndpointWithPostcodeAInTheRequestBodyWithNoSessionId()
                     throws IOException, InterruptedException {
         this.testContext.setResponse(
                 this.addressApiClient.sendPostCodeLookupRequestWithNoSessionId("TEST"));

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -10,8 +10,10 @@ import gov.uk.address.api.client.AddressApiClient;
 import gov.uk.address.api.util.AddressContext;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.junit.jupiter.api.Assertions;
 import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
 import uk.gov.di.ipv.cri.common.library.domain.TestHarnessResponse;
@@ -182,7 +184,8 @@ public class AddressSteps {
     public void aValidStartEventIsReturnedInTheResponseWithTxmaHeader() throws IOException {
         String responseBody = testContext.getTestHarnessResponseBody();
         List<TestHarnessResponse<AuditEvent<Map<String, Object>>>> events =
-                objectMapper.readValue(responseBody, new TypeReference<>() {});
+                objectMapper.readValue(responseBody, new TypeReference<>() {
+                });
 
         assertFalse(events.isEmpty());
         assertEquals(1, events.size());
@@ -203,7 +206,8 @@ public class AddressSteps {
         assertNotNull(responseBody);
 
         List<TestHarnessResponse<AuditEvent<Map<String, Object>>>> events =
-                objectMapper.readValue(responseBody, new TypeReference<>() {});
+                objectMapper.readValue(responseBody, new TypeReference<>() {
+                });
 
         assertFalse(events.isEmpty());
         assertEquals(1, events.size());
@@ -224,7 +228,8 @@ public class AddressSteps {
         String responseBody = testContext.getTestHarnessResponseBody();
 
         List<TestHarnessResponse<AuditEvent<Map<String, Object>>>> testHarnessResponses =
-                objectMapper.readValue(responseBody, new TypeReference<>() {});
+                objectMapper.readValue(responseBody, new TypeReference<>() {
+                });
 
         var events =
                 testHarnessResponses.stream()
@@ -251,7 +256,8 @@ public class AddressSteps {
         String responseBody = testContext.getTestHarnessResponseBody();
 
         List<TestHarnessResponse<AuditEvent<Map<String, Object>>>> testHarnessResponses =
-                objectMapper.readValue(responseBody, new TypeReference<>() {});
+                objectMapper.readValue(responseBody, new TypeReference<>() {
+                });
 
         var events =
                 testHarnessResponses.stream()
@@ -391,4 +397,30 @@ public class AddressSteps {
                 LocalDate.now().minusMonths(3).toString(),
                 payload.at("/vc/credentialSubject/address/1/validFrom").asText());
     }
+
+    @Given("a request is made to the addresses endpoint and it doesn’t include a session_id header")
+    public void a_request_is_made_to_the_addresses_endpoint_and_it_doesn_t_include_a_session_id_header() throws IOException, InterruptedException {
+        this.testContext.setResponse(
+                this.addressApiClient.sendGetAddressesLookupRequestWithOutSessionId());
+    }
+
+    @Then("the endpoint should return a 400 HTTP status code")
+    public void the_endpoint_should_return_a_http_status_code() {
+        assertEquals(400, this.testContext.getResponse().statusCode());
+    }
+
+    @Given("a request is made to the postcode-lookup endpoint without a postcode in the request body")
+    public void a_request_is_made_to_the_postcode_lookup_endpoint_without_a_postcode_in_the_request_body() throws IOException, InterruptedException {
+        this.testContext.setResponse(
+                this.addressApiClient.sendNoPostCodeLookUpRequest());
+                     //   this.testContext.getSessionId()));
+
+
+    }
+    @Then("the endpoint should return a 403 HTTP status code")
+    public void the_endpoint_should_return_a_403_http_status_code() {
+        assertEquals(403, this.testContext.getResponse().statusCode());
+    }
+
+
 }

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -13,7 +13,6 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.junit.jupiter.api.Assertions;
 import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
 import uk.gov.di.ipv.cri.common.library.domain.TestHarnessResponse;

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -13,7 +13,6 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.junit.jupiter.api.Assertions;
 import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
 import uk.gov.di.ipv.cri.common.library.domain.TestHarnessResponse;
@@ -184,8 +183,7 @@ public class AddressSteps {
     public void aValidStartEventIsReturnedInTheResponseWithTxmaHeader() throws IOException {
         String responseBody = testContext.getTestHarnessResponseBody();
         List<TestHarnessResponse<AuditEvent<Map<String, Object>>>> events =
-                objectMapper.readValue(responseBody, new TypeReference<>() {
-                });
+                objectMapper.readValue(responseBody, new TypeReference<>() {});
 
         assertFalse(events.isEmpty());
         assertEquals(1, events.size());
@@ -206,8 +204,7 @@ public class AddressSteps {
         assertNotNull(responseBody);
 
         List<TestHarnessResponse<AuditEvent<Map<String, Object>>>> events =
-                objectMapper.readValue(responseBody, new TypeReference<>() {
-                });
+                objectMapper.readValue(responseBody, new TypeReference<>() {});
 
         assertFalse(events.isEmpty());
         assertEquals(1, events.size());
@@ -228,8 +225,7 @@ public class AddressSteps {
         String responseBody = testContext.getTestHarnessResponseBody();
 
         List<TestHarnessResponse<AuditEvent<Map<String, Object>>>> testHarnessResponses =
-                objectMapper.readValue(responseBody, new TypeReference<>() {
-                });
+                objectMapper.readValue(responseBody, new TypeReference<>() {});
 
         var events =
                 testHarnessResponses.stream()
@@ -256,8 +252,7 @@ public class AddressSteps {
         String responseBody = testContext.getTestHarnessResponseBody();
 
         List<TestHarnessResponse<AuditEvent<Map<String, Object>>>> testHarnessResponses =
-                objectMapper.readValue(responseBody, new TypeReference<>() {
-                });
+                objectMapper.readValue(responseBody, new TypeReference<>() {});
 
         var events =
                 testHarnessResponses.stream()
@@ -399,7 +394,9 @@ public class AddressSteps {
     }
 
     @Given("a request is made to the addresses endpoint and it doesn’t include a session_id header")
-    public void a_request_is_made_to_the_addresses_endpoint_and_it_doesn_t_include_a_session_id_header() throws IOException, InterruptedException {
+    public void
+            a_request_is_made_to_the_addresses_endpoint_and_it_doesn_t_include_a_session_id_header()
+                    throws IOException, InterruptedException {
         this.testContext.setResponse(
                 this.addressApiClient.sendGetAddressesLookupRequestWithOutSessionId());
     }
@@ -409,18 +406,18 @@ public class AddressSteps {
         assertEquals(400, this.testContext.getResponse().statusCode());
     }
 
-    @Given("a request is made to the postcode-lookup endpoint without a postcode in the request body")
-    public void a_request_is_made_to_the_postcode_lookup_endpoint_without_a_postcode_in_the_request_body() throws IOException, InterruptedException {
-        this.testContext.setResponse(
-                this.addressApiClient.sendNoPostCodeLookUpRequest());
-                     //   this.testContext.getSessionId()));
-
+    @Given(
+            "a request is made to the postcode-lookup endpoint without a postcode in the request body")
+    public void
+            a_request_is_made_to_the_postcode_lookup_endpoint_without_a_postcode_in_the_request_body()
+                    throws IOException, InterruptedException {
+        this.testContext.setResponse(this.addressApiClient.sendNoPostCodeLookUpRequest());
+        //   this.testContext.getSessionId()));
 
     }
+
     @Then("the endpoint should return a 403 HTTP status code")
     public void the_endpoint_should_return_a_403_http_status_code() {
         assertEquals(403, this.testContext.getResponse().statusCode());
     }
-
-
 }

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -412,7 +412,6 @@ public class AddressSteps {
             a_request_is_made_to_the_postcode_lookup_endpoint_without_a_postcode_in_the_request_body()
                     throws IOException, InterruptedException {
         this.testContext.setResponse(this.addressApiClient.sendNoPostCodeLookUpRequest());
-        //   this.testContext.getSessionId()));
 
     }
 

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -412,7 +412,6 @@ public class AddressSteps {
             a_request_is_made_to_the_postcode_lookup_endpoint_without_a_postcode_in_the_request_body()
                     throws IOException, InterruptedException {
         this.testContext.setResponse(this.addressApiClient.sendNoPostCodeLookUpRequest());
-
     }
 
     @Then("the endpoint should return a 403 HTTP status code")

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -13,6 +13,7 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import software.amazon.awssdk.awscore.util.SignerOverrideUtils;
 import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
 import uk.gov.di.ipv.cri.common.library.domain.TestHarnessResponse;
@@ -393,29 +394,38 @@ public class AddressSteps {
                 payload.at("/vc/credentialSubject/address/1/validFrom").asText());
     }
 
-    @Given("a request is made to the addresses endpoint and it doesn’t include a session_id header")
-    public void
-            a_request_is_made_to_the_addresses_endpoint_and_it_doesn_t_include_a_session_id_header()
+    @Given("a request is made to the addresses endpoint and it does not include a session_id header")
+    public void aRequestIsMadeToTheAddressesEndpointWithoutSessionIdHeader()
                     throws IOException, InterruptedException {
         this.testContext.setResponse(
                 this.addressApiClient.sendGetAddressesLookupRequestWithOutSessionId());
     }
 
     @Then("the endpoint should return a 400 HTTP status code")
-    public void the_endpoint_should_return_a_http_status_code() {
+    public void theEndpointShouldReturnA400HttpStatusCode() throws ParseException, IOException {
         assertEquals(400, this.testContext.getResponse().statusCode());
     }
-
-    @Given(
-            "a request is made to the postcode-lookup endpoint without a postcode in the request body")
-    public void
-            a_request_is_made_to_the_postcode_lookup_endpoint_without_a_postcode_in_the_request_body()
+    @Given("a request is made to the postcode-lookup endpoint with postcode and no session id in the request body")
+    public void aRequestIsMadeToThePostcodeLookupEndpointWithPostcodeAndNoSessionIdInTheRequestBody()
                     throws IOException, InterruptedException {
-        this.testContext.setResponse(this.addressApiClient.sendNoPostCodeLookUpRequest());
+        this.testContext.setResponse(this.addressApiClient.sendNoPostCodeNoSessionIdLookUpRequest("TEST"));
     }
+    @Given("a request is made to the postcode-lookup endpoint without a postcode and with session id in the request body")
+    public void aRequestIsMadeToThePostcodeLookupEndpointWithoutPostcodeAndWithSessionIdInTheRequestBody()
+            throws IOException, InterruptedException {
+        this.testContext.setResponse(this.addressApiClient.sendNoPostCodeWithSessionIdLookUpRequest(this.testContext.getSessionId()));
+    }
+    @Then("the response body contains no session id error")
+    public void theResponseBodyContainsNoSessionIdError() {
+        var responseBody = this.testContext.getResponse().body();
+        assertNotNull(responseBody);
+        assertEquals("{\"message\": \"Missing required request parameters: [session_id]\"}",responseBody );
+    }
+    @Then("the response body contains no postcode error")
+    public void theResponseBodyContainsNoPostcodeError() {
+        var responseBody = this.testContext.getResponse().body();
+        assertNotNull(responseBody);
+        assertEquals("\"Missing postcode in request body.\"",responseBody );
 
-    @Then("the endpoint should return a 403 HTTP status code")
-    public void the_endpoint_should_return_a_403_http_status_code() {
-        assertEquals(403, this.testContext.getResponse().statusCode());
     }
 }

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -416,9 +416,9 @@ public class AddressSteps {
     }
 
     @Given(
-            "a request is made to the postcode-lookup endpoint without a postcode and with session id in the request body")
+            "a request is made to the postcode-lookup endpoint without a postcode in the body and with session id in the header")
     public void
-            aRequestIsMadeToThePostcodeLookupEndpointWithoutPostcodeAndWithSessionIdInTheRequestBody()
+            aRequestIsMadeToThePostcodeLookupEndpointWithoutaPostcodeInTheBodyAndWithSessionIdInTheHeader()
                     throws IOException, InterruptedException {
         this.testContext.setResponse(
                 this.addressApiClient.sendNoPostCodeWithSessionIdLookUpRequest(

--- a/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
+++ b/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
@@ -21,15 +21,12 @@ Feature: Address API unhappy path test
     Then the address is not saved
 
 
-
     @no_session_id
   Scenario: No session_id header
   Given a request is made to the addresses endpoint and it doesn’t include a session_id header
   Then the endpoint should return a 400 HTTP status code
 
-
   @no_postcode
    Scenario:No postcode in the request body
    Given  a request is made to the postcode-lookup endpoint without a postcode in the request body
    Then the endpoint should return a 400 HTTP status code
-

--- a/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
+++ b/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
@@ -19,3 +19,17 @@ Feature: Address API unhappy path test
     # Address
     When the user selects address without country code
     Then the address is not saved
+
+
+
+    @no_session_id
+  Scenario: No session_id header
+  Given a request is made to the addresses endpoint and it doesn’t include a session_id header
+  Then the endpoint should return a 400 HTTP status code
+
+
+  @no_postcode
+   Scenario:No postcode in the request body
+   Given  a request is made to the postcode-lookup endpoint without a postcode in the request body
+   Then the endpoint should return a 400 HTTP status code
+

--- a/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
+++ b/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
@@ -38,6 +38,6 @@ Feature: Address API unhappy path test
     Given user has the test-identity 197 in the form of a signed JWT string
     When user sends a POST request to session end point
     Then user gets a session-id
-    Given a request is made to the postcode-lookup endpoint without a postcode and with session id in the request body
+    Given a request is made to the postcode-lookup endpoint without a postcode in the body and with session id in the header
     Then the endpoint should return a 400 HTTP status code
     And the response body contains no postcode error

--- a/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
+++ b/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
@@ -29,7 +29,7 @@ Feature: Address API unhappy path test
 
   @with_postcode @with_no_session_id
   Scenario: With postcode and no session_id in the request body
-    Given a request is made to the postcode-lookup endpoint with postcode and no session id in the request body
+    Given a request is made to the postcode-lookup endpoint with postcode in the request body with no session id header
     Then the endpoint should return a 400 HTTP status code
     And the response body contains no session id error
 

--- a/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
+++ b/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
@@ -21,12 +21,23 @@ Feature: Address API unhappy path test
     Then the address is not saved
 
 
-    @no_session_id
+  @no_session_id
   Scenario: No session_id header
-  Given a request is made to the addresses endpoint and it doesn’t include a session_id header
-  Then the endpoint should return a 400 HTTP status code
+    Given a request is made to the addresses endpoint and it does not include a session_id header
+    Then the endpoint should return a 400 HTTP status code
+    And the response body contains no session id error
 
-  @no_postcode
-   Scenario:No postcode in the request body
-   Given  a request is made to the postcode-lookup endpoint without a postcode in the request body
-   Then the endpoint should return a 400 HTTP status code
+  @with_postcode @with_no_session_id
+  Scenario: With postcode and no session_id in the request body
+    Given a request is made to the postcode-lookup endpoint with postcode and no session id in the request body
+    Then the endpoint should return a 400 HTTP status code
+    And the response body contains no session id error
+
+  @no_postcode @with_session_id
+  Scenario: No postcode and with session_id in the request body
+    Given user has the test-identity 197 in the form of a signed JWT string
+    When user sends a POST request to session end point
+    Then user gets a session-id
+    Given a request is made to the postcode-lookup endpoint without a postcode and with session id in the request body
+    Then the endpoint should return a 400 HTTP status code
+    And the response body contains no postcode error


### PR DESCRIPTION
 What changed
Added no session_id header and no postcode in the request body to the unhappy path Java cucumber API tests

Why did it change
There is a need for additional no session_id header and no postcode in the request body to ensure endpoints are working correctly and if these conditions are satisfied: (a) no session_id (b) with session_id and no postcode (c) with postcode and no session_id. The endpoint should return a 400 HTTP status code.

ScreenShot
![image](https://github.com/user-attachments/assets/d252227b-ccfc-4e45-989c-e22874961cd3)


