### PR TITLE
fix: pii-redact-handler.ts

### DIFF
--- a/lambdas/pii-redact/src/pii-redact-handler.ts
+++ b/lambdas/pii-redact/src/pii-redact-handler.ts
@@ -23,7 +23,7 @@ export class PiiRedactHandler implements LambdaInterface {
             const logDataBuffer = Buffer.from(logDataBase64, "base64");
             const decompressedData = zlib.unzipSync(logDataBuffer).toString("utf-8");
             const logEvents: CloudWatchLogsDecodedData = JSON.parse(decompressedData);
-            const piiRedactLogGroup = logEvents.logGroup + "-pii-redacted";
+            const piiRedactLogGroup = logEvents.logGroup + "-redacted";
             const logStream = logEvents.logStream;
 
             try {


### PR DESCRIPTION
## Proposed changes

### What changed
pii-redact-handler.ts

### Why did it change
The log group name was changed and the handler used a hardcoded postfix to find the log group. This meant the redactor couldn't find the target log group to store the redacted logs.

**Screenshots**

<img width="1246" alt="Screenshot 2025-04-10 at 14 56 55" src="https://github.com/user-attachments/assets/7c57f4e1-d07c-496a-9ed4-c4fef3d315f0" />

<img width="1922" alt="Screenshot 2025-04-10 at 14 57 04" src="https://github.com/user-attachments/assets/41ad2c63-b6c6-4287-a789-07b483143af4" />

### Issue tracking

- [OJ-2862](https://govukverify.atlassian.net/browse/OJ-2862)


[OJ-2862]: https://govukverify.atlassian.net/browse/OJ-2862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ