### PR TITLE
OJ-3142-PostcodeLookuptest

### DIFF
--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -400,5 +400,6 @@ public class AddressSteps {
     @Then("the response body is Error processing postcode lookup")
     public void theResponseBodyIsErrorProcessingPostcodeLookup() {
         String responseBody = this.testContext.getResponse().body();
+       assertEquals("\"Error processing postcode lookup: \"" ,responseBody );
     }
 }

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -10,12 +10,8 @@ import gov.uk.address.api.client.AddressApiClient;
 import gov.uk.address.api.util.AddressContext;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
-import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import net.minidev.json.JSONUtil;
-import org.junit.Assert;
-import org.w3c.dom.ls.LSOutput;
 import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
 import uk.gov.di.ipv.cri.common.library.domain.TestHarnessResponse;
@@ -404,6 +400,5 @@ public class AddressSteps {
     @Then("the response body is Error processing postcode lookup")
     public void theResponseBodyIsErrorProcessingPostcodeLookup() {
         String responseBody = this.testContext.getResponse().body();
-        // System.out.println("The response body is " + " " + responseBody);
     }
 }

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -13,6 +13,9 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import net.minidev.json.JSONUtil;
+import org.junit.Assert;
+import org.w3c.dom.ls.LSOutput;
 import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
 import uk.gov.di.ipv.cri.common.library.domain.TestHarnessResponse;
@@ -75,7 +78,7 @@ public class AddressSteps {
         this.addressContext = new AddressContext();
     }
 
-    @When("the user performs a postcode lookup for post code {string}")
+    @And("the user performs a postcode lookup for post code {string}")
     public void theUserPerformsAPostcodeLookupForPostCode(String postcode)
             throws IOException, InterruptedException {
         this.testContext.setResponse(
@@ -393,51 +396,14 @@ public class AddressSteps {
                 payload.at("/vc/credentialSubject/address/1/validFrom").asText());
     }
 
-    @Given(
-            "a request is made to the addresses endpoint and it does not include a session_id header")
-    public void aRequestIsMadeToTheAddressesEndpointWithoutSessionIdHeader()
-            throws IOException, InterruptedException {
-        this.testContext.setResponse(
-                this.addressApiClient.sendGetAddressesLookupRequestWithOutSessionId());
+    @When("the response HTTP status code is {int}")
+    public void theResponseHttpStatusCodeIs(Integer int1) {
+        assertEquals(404, this.testContext.getResponse().statusCode());
     }
 
-    @Then("the endpoint should return a 400 HTTP status code")
-    public void theEndpointShouldReturnA400HttpStatusCode() {
-        assertEquals(400, this.testContext.getResponse().statusCode());
-    }
-
-    @Given(
-            "a request is made to the postcode-lookup endpoint with postcode in the request body with no session id header")
-    public void
-            aRequestIsMadeToThePostcodeLookupEndpointWithPostcodeAInTheRequestBodyWithNoSessionId()
-                    throws IOException, InterruptedException {
-        this.testContext.setResponse(
-                this.addressApiClient.sendPostCodeLookupRequestWithNoSessionId("TEST"));
-    }
-
-    @Given(
-            "a request is made to the postcode-lookup endpoint without a postcode in the body and with session id in the header")
-    public void
-            aRequestIsMadeToThePostcodeLookupEndpointWithoutaPostcodeInTheBodyAndWithSessionIdInTheHeader()
-                    throws IOException, InterruptedException {
-        this.testContext.setResponse(
-                this.addressApiClient.sendNoPostCodeWithSessionIdLookUpRequest(
-                        this.testContext.getSessionId()));
-    }
-
-    @Then("the response body contains no session id error")
-    public void theResponseBodyContainsNoSessionIdError() {
-        var responseBody = this.testContext.getResponse().body();
-        assertNotNull(responseBody);
-        assertEquals(
-                "{\"message\": \"Missing required request parameters: [session_id]\"}",
-                responseBody);
-    }
-
-    @Then("the response body contains no postcode error")
-    public void theResponseBodyContainsNoPostcodeError() {
-        var responseBody = this.testContext.getResponse().body();
-        assertNotNull(responseBody);
-        assertEquals("\"Missing postcode in request body.\"", responseBody);
+    @Then("the response body is Error processing postcode lookup")
+    public void theResponseBodyIsErrorProcessingPostcodeLookup() {
+        String responseBody = this.testContext.getResponse().body();
+        System.out.println("The response body is " + " " + responseBody);
     }
 }

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -404,6 +404,6 @@ public class AddressSteps {
     @Then("the response body is Error processing postcode lookup")
     public void theResponseBodyIsErrorProcessingPostcodeLookup() {
         String responseBody = this.testContext.getResponse().body();
-        System.out.println("The response body is " + " " + responseBody);
+        // System.out.println("The response body is " + " " + responseBody);
     }
 }

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -403,6 +403,7 @@ public class AddressSteps {
         String responseBody = this.testContext.getResponse().body();
         assertEquals("\"Error processing postcode lookup: \"", responseBody);
     }
+
     @Given(
             "a request is made to the addresses endpoint and it does not include a session_id header")
     public void aRequestIsMadeToTheAddressesEndpointWithoutSessionIdHeader()
@@ -419,8 +420,8 @@ public class AddressSteps {
     @Given(
             "a request is made to the postcode-lookup endpoint with postcode in the request body with no session id header")
     public void
-    aRequestIsMadeToThePostcodeLookupEndpointWithPostcodeAInTheRequestBodyWithNoSessionId()
-            throws IOException, InterruptedException {
+            aRequestIsMadeToThePostcodeLookupEndpointWithPostcodeAInTheRequestBodyWithNoSessionId()
+                    throws IOException, InterruptedException {
         this.testContext.setResponse(
                 this.addressApiClient.sendPostCodeLookupRequestWithNoSessionId("TEST"));
     }
@@ -428,8 +429,8 @@ public class AddressSteps {
     @Given(
             "a request is made to the postcode-lookup endpoint without a postcode in the body and with session id in the header")
     public void
-    aRequestIsMadeToThePostcodeLookupEndpointWithoutaPostcodeInTheBodyAndWithSessionIdInTheHeader()
-            throws IOException, InterruptedException {
+            aRequestIsMadeToThePostcodeLookupEndpointWithoutaPostcodeInTheBodyAndWithSessionIdInTheHeader()
+                    throws IOException, InterruptedException {
         this.testContext.setResponse(
                 this.addressApiClient.sendNoPostCodeWithSessionIdLookUpRequest(
                         this.testContext.getSessionId()));
@@ -444,17 +445,10 @@ public class AddressSteps {
                 responseBody);
     }
 
-
     @Then("the response body contains no postcode error")
     public void theResponseBodyContainsNoPostcodeError() {
         var responseBody = this.testContext.getResponse().body();
         assertNotNull(responseBody);
         assertEquals("\"Missing postcode in request body.\"", responseBody);
     }
-
-
-
-
-
-
 }

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -75,7 +75,7 @@ public class AddressSteps {
         this.addressContext = new AddressContext();
     }
 
-    @And("the user performs a postcode lookup for post code {string}")
+    @When("the user performs a postcode lookup for post code {string}")
     public void theUserPerformsAPostcodeLookupForPostCode(String postcode)
             throws IOException, InterruptedException {
         this.testContext.setResponse(
@@ -393,8 +393,8 @@ public class AddressSteps {
                 payload.at("/vc/credentialSubject/address/1/validFrom").asText());
     }
 
-    @When("the response HTTP status code is {int}")
-    public void theResponseHttpStatusCodeIs(Integer int1) {
+    @When("the response HTTP status code is 404")
+    public void theResponseHttpStatusCodeIs() {
         assertEquals(404, this.testContext.getResponse().statusCode());
     }
 

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -400,6 +400,6 @@ public class AddressSteps {
     @Then("the response body is Error processing postcode lookup")
     public void theResponseBodyIsErrorProcessingPostcodeLookup() {
         String responseBody = this.testContext.getResponse().body();
-       assertEquals("\"Error processing postcode lookup: \"" ,responseBody );
+        assertEquals("\"Error processing postcode lookup: \"", responseBody);
     }
 }

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -75,7 +75,7 @@ public class AddressSteps {
         this.addressContext = new AddressContext();
     }
 
-    @When("the user performs a postcode lookup for post code {string}")
+    @And("the user performs a postcode lookup for post code {string}")
     public void theUserPerformsAPostcodeLookupForPostCode(String postcode)
             throws IOException, InterruptedException {
         this.testContext.setResponse(
@@ -393,7 +393,7 @@ public class AddressSteps {
                 payload.at("/vc/credentialSubject/address/1/validFrom").asText());
     }
 
-    @When("the response HTTP status code is 404")
+    @Then("the response HTTP status code is 404")
     public void theResponseHttpStatusCodeIs() {
         assertEquals(404, this.testContext.getResponse().statusCode());
     }

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -10,6 +10,7 @@ import gov.uk.address.api.client.AddressApiClient;
 import gov.uk.address.api.util.AddressContext;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
@@ -402,4 +403,58 @@ public class AddressSteps {
         String responseBody = this.testContext.getResponse().body();
         assertEquals("\"Error processing postcode lookup: \"", responseBody);
     }
+    @Given(
+            "a request is made to the addresses endpoint and it does not include a session_id header")
+    public void aRequestIsMadeToTheAddressesEndpointWithoutSessionIdHeader()
+            throws IOException, InterruptedException {
+        this.testContext.setResponse(
+                this.addressApiClient.sendGetAddressesLookupRequestWithOutSessionId());
+    }
+
+    @Then("the endpoint should return a 400 HTTP status code")
+    public void theEndpointShouldReturnA400HttpStatusCode() {
+        assertEquals(400, this.testContext.getResponse().statusCode());
+    }
+
+    @Given(
+            "a request is made to the postcode-lookup endpoint with postcode in the request body with no session id header")
+    public void
+    aRequestIsMadeToThePostcodeLookupEndpointWithPostcodeAInTheRequestBodyWithNoSessionId()
+            throws IOException, InterruptedException {
+        this.testContext.setResponse(
+                this.addressApiClient.sendPostCodeLookupRequestWithNoSessionId("TEST"));
+    }
+
+    @Given(
+            "a request is made to the postcode-lookup endpoint without a postcode in the body and with session id in the header")
+    public void
+    aRequestIsMadeToThePostcodeLookupEndpointWithoutaPostcodeInTheBodyAndWithSessionIdInTheHeader()
+            throws IOException, InterruptedException {
+        this.testContext.setResponse(
+                this.addressApiClient.sendNoPostCodeWithSessionIdLookUpRequest(
+                        this.testContext.getSessionId()));
+    }
+
+    @Then("the response body contains no session id error")
+    public void theResponseBodyContainsNoSessionIdError() {
+        var responseBody = this.testContext.getResponse().body();
+        assertNotNull(responseBody);
+        assertEquals(
+                "{\"message\": \"Missing required request parameters: [session_id]\"}",
+                responseBody);
+    }
+
+
+    @Then("the response body contains no postcode error")
+    public void theResponseBodyContainsNoPostcodeError() {
+        var responseBody = this.testContext.getResponse().body();
+        assertNotNull(responseBody);
+        assertEquals("\"Missing postcode in request body.\"", responseBody);
+    }
+
+
+
+
+
+
 }

--- a/integration-tests/src/test/resources/features/PostcodeLookupRequest.feature
+++ b/integration-tests/src/test/resources/features/PostcodeLookupRequest.feature
@@ -33,11 +33,11 @@ Feature: valid postcode test
       | 197                        | SW1A 2AA     |
 
   @postcode-lookup
-  Scenario Outline: Rate limit Is returned by OS API?
+  Scenario Outline: Rate limit Is returned by OS API
     Given user has the test-identity <testUserDataSheetRowNumber> in the form of a signed JWT string
     When user sends a POST request to session end point
     And the user performs a postcode lookup for post code "<testPostCode>"
-    And the response HTTP status code is 404
+    Then the response HTTP status code is 404
     Then the response body is Error processing postcode lookup
 
     Examples:

--- a/integration-tests/src/test/resources/features/PostcodeLookupRequest.feature
+++ b/integration-tests/src/test/resources/features/PostcodeLookupRequest.feature
@@ -33,7 +33,7 @@ Feature: valid postcode test
       | 197                        | SW1A 2AA     |
 
   @postcode-lookup
-  Scenario Outline: postcode-lookup with too much request
+  Scenario Outline: Rate limit Is returned by OS API?
     Given user has the test-identity <testUserDataSheetRowNumber> in the form of a signed JWT string
     When user sends a POST request to session end point
     And the user performs a postcode lookup for post code "<testPostCode>"

--- a/integration-tests/src/test/resources/features/PostcodeLookupRequest.feature
+++ b/integration-tests/src/test/resources/features/PostcodeLookupRequest.feature
@@ -31,3 +31,15 @@ Feature: valid postcode test
     Examples:
       | testUserDataSheetRowNumber | testPostCode |
       | 197                        | SW1A 2AA     |
+
+  @postcode-lookup
+  Scenario Outline: postcode-lookup with too much request
+    Given user has the test-identity <testUserDataSheetRowNumber> in the form of a signed JWT string
+    When user sends a POST request to session end point
+    And the user performs a postcode lookup for post code "<testPostCode>"
+    And the response HTTP status code is 404
+    Then the response body is Error processing postcode lookup
+
+      Examples:
+        | testUserDataSheetRowNumber | testPostCode |
+        | 197                        | E11 3BW      |

--- a/integration-tests/src/test/resources/features/PostcodeLookupRequest.feature
+++ b/integration-tests/src/test/resources/features/PostcodeLookupRequest.feature
@@ -40,6 +40,6 @@ Feature: valid postcode test
     And the response HTTP status code is 404
     Then the response body is Error processing postcode lookup
 
-      Examples:
-        | testUserDataSheetRowNumber | testPostCode |
-        | 197                        | E11 3BW      |
+    Examples:
+      | testUserDataSheetRowNumber | testPostCode |
+      | 197                        | E11 3BW      |


### PR DESCRIPTION
## Proposed changes
This API has a rate limit policy documented that means when we send too many requests, it will respond with HTTP status code 429 in the lambda. We wrote a test to cover this scenario.

### What changed
The response that we expect from the postcode lookup handler is a 404 HTTP status code indicating that no results could be found with an error message in the response body. 

### Why did it change
To ensure that endpoints are working correctly and the response HTTP status code is 404 and "Error processing postcode lookup" is generated at the response body.

SCREENSHOT
![image](https://github.com/user-attachments/assets/e9c32cab-29c0-4c7d-96fd-7fb813561a76)


