### PR TITLE
feat: better organise build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	alias(libs.plugins.java)
 	alias(libs.plugins.spotless)
 	alias(libs.plugins.sonarqube)
+	alias(libs.plugins.jacoco)
 }
 
 defaultTasks 'clean', 'spotlessApply', 'build'
@@ -14,6 +15,7 @@ repositories {
 
 subprojects {
 	apply plugin: 'java'
+
 	java {
 		sourceCompatibility = JavaVersion.VERSION_11
 		targetCompatibility = JavaVersion.VERSION_11
@@ -34,39 +36,24 @@ subprojects {
 	dependencies {
 		implementation platform("software.amazon.awssdk:bom:2.26.20")
 		implementation platform("com.fasterxml.jackson:jackson-bom:2.18.3")
-
-		implementation(libs.dynamodb)
-		implementation(libs.dynamodb.enhanced)
-		implementation(libs.lambda)
-		implementation(libs.aws.lambda.events)
-		implementation(libs.cri.common.lib)
-		implementation(libs.sqs)
-		implementation(libs.kms)
-
-		implementation(libs.bundles.jackson)
-		implementation(libs.bundles.powertools)
-
-		implementation(libs.nimbusds.oauth)
-		implementation(libs.nimbusds.jwt)
-
-		implementation(libs.hamcrest)
-
-		implementation(libs.junit.engine)
-
-		implementation(libs.system.stubs.core)
-		implementation(libs.system.stubs.jupiter)
-
 		implementation(libs.bundles.otel)
-
-		testImplementation(libs.bundles.tests)
-		testImplementation(libs.pact.junit5)
-		testImplementation(libs.pact.provider)
-		testImplementation(libs.lambda.tests)
 	}
 
 	tasks.register("pactTests", Test) {
 		useJUnitPlatform {
 			includeTags 'Pact'
+		}
+	}
+
+	test {
+		useJUnitPlatform()
+		finalizedBy jacocoTestReport
+	}
+
+	jacocoTestReport {
+		dependsOn test
+		reports {
+			xml.required.set(true)
 		}
 	}
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ cri-common-lib = "4.2.0"
 pact-provider = "4.5.11"
 webcompere = "2.1.6"
 open-telemetry = "2.12.0-alpha"
+slf4j = "2.0.13"
 
 # Plugins
 spotless = "6.23.+"
@@ -64,6 +65,9 @@ pact-provider = { module = "au.com.dius.pact:provider", version.ref = "pact-prov
 otel-aws-autoconfigure = { module = "io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2-autoconfigure", version.ref = "open-telemetry" }
 otel-http-client = { module = "io.opentelemetry.instrumentation:opentelemetry-java-http-client", version.ref = "open-telemetry" }
 
+# slf4j
+slf4j = { module = "org.slf4j:slf4j-log4j12", version.ref = "slf4j" }
+
 [bundles]
 jackson = [ "jackson-core", "jackson-annotations", "jackson-databind", "jackson-jdk8", "jackson-jsr310" ]
 nimbus = [ "nimbusds-jwt", "nimbusds-oauth" ]
@@ -73,6 +77,7 @@ tests = [ "junit-api", "junit-params", "mockito-junit", "mockito-inline" ]
 powertools = [ "powertools-logging", "powertools-metrics", "powertools-parameters" ]
 webcompere = [ "system-stubs-core", "system-stubs-jupiter" ]
 pact = [ "pact-junit5", "pact-provider" ]
+dynamodb = [ "dynamodb", "dynamodb-enhanced" ]
 
 [plugins]
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/lambdas/address/build.gradle
+++ b/lambdas/address/build.gradle
@@ -1,6 +1,5 @@
 plugins {
 	alias(libs.plugins.java)
-	alias(libs.plugins.jacoco)
 	alias(libs.plugins.post.compile.weaving)
 }
 
@@ -8,6 +7,12 @@ dependencies {
 	runtimeOnly libs.bundles.otel
 
 	implementation project(":lib")
+	implementation(libs.lambda)
+	implementation(libs.aws.lambda.events)
+	implementation(libs.cri.common.lib)
+	implementation(libs.bundles.jackson)
+	implementation(libs.bundles.nimbus)
+	implementation(libs.bundles.dynamodb)
 
 	aspect libs.bundles.powertools
 
@@ -15,16 +20,4 @@ dependencies {
 	testImplementation libs.hamcrest
 
 	testRuntimeOnly libs.bundles.test.runtime
-}
-
-test {
-	useJUnitPlatform()
-	finalizedBy jacocoTestReport
-}
-
-jacocoTestReport {
-	dependsOn test
-	reports {
-		xml.required.set(true)
-	}
 }

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -9,14 +9,21 @@ dependencies {
 
 	runtimeOnly libs.bundles.otel
 
+	implementation(libs.lambda)
+	implementation(libs.aws.lambda.events)
+	implementation(libs.cri.common.lib)
+	implementation(libs.kms)
+	implementation(libs.sqs)
+	implementation(libs.bundles.nimbus)
+	implementation(libs.bundles.jackson)
+	implementation(libs.bundles.dynamodb)
+
 	aspect libs.bundles.powertools
 
-	testImplementation "org.slf4j:slf4j-log4j12:2.0.13"
-
+	testImplementation libs.slf4j
 	testImplementation libs.bundles.tests
 	testImplementation libs.hamcrest
 	testImplementation libs.bundles.pact
-
 	testImplementation libs.bundles.webcompere
 
 	testRuntimeOnly libs.bundles.test.runtime
@@ -27,11 +34,4 @@ test {
 		excludeTags 'Pact'
 	}
 	finalizedBy jacocoTestReport
-}
-
-jacocoTestReport {
-	dependsOn test
-	reports {
-		xml.required.set(true)
-	}
 }

--- a/lambdas/postcode-lookup/build.gradle
+++ b/lambdas/postcode-lookup/build.gradle
@@ -1,6 +1,5 @@
 plugins {
 	alias(libs.plugins.java)
-	alias(libs.plugins.jacoco)
 	alias(libs.plugins.post.compile.weaving)
 }
 
@@ -8,23 +7,18 @@ dependencies {
 	runtimeOnly libs.bundles.otel
 
 	implementation project(":lib")
+	implementation(libs.cri.common.lib)
+	implementation(libs.aws.lambda.events)
+	implementation(libs.lambda)
+	implementation(libs.sqs)
+	implementation libs.bundles.nimbus
+	implementation libs.bundles.dynamodb
+	implementation libs.bundles.jackson
 
 	aspect libs.bundles.powertools
 
-	testImplementation libs.bundles.jackson
 	testImplementation libs.junit.api
+	testImplementation libs.bundles.tests
 
 	testRuntimeOnly libs.bundles.test.runtime
-}
-
-test {
-	useJUnitPlatform()
-	finalizedBy jacocoTestReport
-}
-
-jacocoTestReport {
-	dependsOn test
-	reports {
-		xml.required.set(true)
-	}
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,10 +1,14 @@
 plugins {
-	id "jacoco"
-	id "java-library"
-	id "io.freefair.aspectj.post-compile-weaving" version "6.3.0"
+	alias(libs.plugins.post.compile.weaving)
 }
 
 dependencies {
+	implementation(libs.lambda)
+	implementation(libs.dynamodb)
+	implementation(libs.dynamodb.enhanced)
+	implementation(libs.cri.common.lib)
+	implementation(libs.bundles.jackson)
+
 	aspect libs.bundles.powertools
 
 	testImplementation libs.bundles.tests
@@ -12,23 +16,4 @@ dependencies {
 	testImplementation libs.lambda.tests
 
 	testRuntimeOnly libs.bundles.test.runtime
-}
-
-tasks.named("jar") {
-	manifest {
-		attributes("Implementation-Title": project.name,
-		"Implementation-Version": project.version)
-	}
-}
-
-test {
-	useJUnitPlatform()
-	finalizedBy jacocoTestReport
-}
-
-jacocoTestReport {
-	dependsOn test
-	reports {
-		xml.required.set(true)
-	}
 }


### PR DESCRIPTION
## Proposed changes

### What and why did it change
This was raised to remove the duplication and redundancy in our build.gradle files for example, we introduced dependencies into the sub modules via the parent build.gradle that were not needed by the sub modules. 

Additionally, removed a lot of the duplication. 

### Issue tracking
- [OJ-3154](https://govukverify.atlassian.net/browse/OJ-3154)


[OJ-3154]: https://govukverify.atlassian.net/browse/OJ-3154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ