### PR TITLE
feat: increase sleep to 10 seconds

### DIFF
--- a/lambdas/pii-redact/src/pii-redact-handler.ts
+++ b/lambdas/pii-redact/src/pii-redact-handler.ts
@@ -27,6 +27,8 @@ export class PiiRedactHandler implements LambdaInterface {
             const logStream = logEvents.logStream;
 
             try {
+                await new Promise((resolve) => setTimeout(resolve, 1000));
+
                 await cloudwatch.send(
                     new CreateLogStreamCommand({
                         logGroupName: piiRedactLogGroup,

--- a/step-functions/add-expiry-to-addresses.asl.json
+++ b/step-functions/add-expiry-to-addresses.asl.json
@@ -165,7 +165,7 @@
       "Parameters": {
         "FunctionName": "${SleepFunction}",
         "Payload": {
-          "ms": "1000"
+          "ms": "10000"
         }
       },
       "Retry": [

--- a/step-functions/add-expiry-to-addresses.asl.json
+++ b/step-functions/add-expiry-to-addresses.asl.json
@@ -147,7 +147,7 @@
         {
           "Variable": "$.scan.LastEvaluatedKey.sessionId.S",
           "IsPresent": true,
-          "Next": "Pause for 1 second"
+          "Next": "Pause for 10 second"
         }
       ],
       "Default": "Total records processed"
@@ -159,7 +159,7 @@
         "Total Records Updated.$": "States.MathAdd($.counter.value, $.scan.Count)"
       }
     },
-    "Pause for 1 second": {
+    "Pause for 10 second": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {


### PR DESCRIPTION
## Proposed changes

### What changed
* Increase sleep to 10 seconds for add-expiry-date step function
* Add a 1second wait before creating log stream as create log stream has a 50 tps rate limit. 

## Why did it change
We were getting 400 responses in Dynatrace for https://logs.eu-west-2.amazonaws.com/

https://govukverify.atlassian.net/browse/OJ-2862
