### PR TITLE
IPS-1722: Update bucket name

### DIFF
--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -78,9 +78,12 @@ paths:
           Fn::GetAtt: [ "JWKSBucketRole", "Arn" ]
         uri:
           Fn::Sub:
-            - "arn:aws:apigateway:${AWS::Region}:s3:path/${s3bucket}/jwks.json"
-            - s3bucket:
-                Fn::ImportValue: core-infrastructure-PublishedKeysS3BucketName
+            - "arn:aws:apigateway:${AWS::Region}:s3:path/govuk-one-login-address-published-keys-${env}/jwks.json"
+            - env:
+                Fn::If:
+                  - IsLocalDevEnvironment
+                  - dev
+                  - Ref: Environment
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1061,11 +1061,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - "s3:Get*"
-                Resource:
-                  Fn::Sub:
-                    - "arn:aws:s3:::${s3bucket}/jwks.json"
-                    - s3bucket:
-                        Fn::ImportValue: core-infrastructure-PublishedKeysS3BucketName
+                Resource: !Sub
+                  - "arn:aws:s3:::govuk-one-login-address-published-keys-${env}/jwks.json"
+                  - env: !If [ IsLocalDevEnvironment, "dev", !Ref Environment ]
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary


### PR DESCRIPTION
### What changed

- Hardcode bucket name

### Why did it change

- Remove dependency on export from core-infrastructure-stack
- Fix `Update canceled. Cannot update export core-infrastructure-PublishedKeysS3BucketName as it is in use by address-cri-api-v1.`

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1722](https://govukverify.atlassian.net/browse/IPS-1722)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[IPS-1722]: https://govukverify.atlassian.net/browse/IPS-1722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ