### PR TITLE
OJ-2968: Change session to use TS lambda

### DIFF
--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -138,7 +138,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-SessionFunction/invocations
+          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-SessionFunctionTS/invocations
         responses:
           default:
             statusCode: "200"


### PR DESCRIPTION
## Proposed changes

### What changed

Switch the `/session` endpoint to use the TS lambda instead of the Java one.

### Why did it change

This CRI is using the following java common lambdas, which should be swapped to the typescript versions as in Experian KBV and Check HMRC CRIs

### Issue tracking
- [OJ-2968](https://govukverify.atlassian.net/browse/OJ-2968)