### PR TITLE
OJ-3214: Change SupportManualURL to mapping

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -44,10 +44,6 @@ Parameters:
     Description: "The stack containing the TXMA infrastructure"
     Type: String
     Default: txma-infrastructure
-  SupportManualURL:
-    Type: String
-    Default: "https://team-manual.account.gov.uk/teams/CRI-Orange-team/supporting-cri-orange/address-credential-issuer-runbook"
-    Description: The support manual URL to be provided in alarm messages.
 
 Conditions:
   UseSecretPrefix: !Not [!Equals [!Ref SecretPrefix, "none"]]
@@ -191,6 +187,10 @@ Globals:
         }
 
 Mappings:
+  StaticVariables:
+    Urls:
+      SupportManualURL: "https://team-manual.account.gov.uk/teams/CRI-Orange-team/supporting-cri-orange/address-credential-issuer-runbook"
+
   MemorySizeMapping:
     Environment:
       dev: 2048
@@ -784,7 +784,9 @@ Resources:
   AddressLambdaErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: !Sub Address ${Environment} lambda errors
+      AlarmDescription: !Sub
+        - "Address ${Environment} lambda errors. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
@@ -807,7 +809,9 @@ Resources:
   SessionLambdaFailedToVerifyJWTAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: Errors verifying JWTs that have been been received by the session lambda.
+      AlarmDescription: !Sub
+        - "Errors verifying JWTs that have been been received by the session lambda. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
@@ -832,7 +836,9 @@ Resources:
   TokenLambdaFailedToVerifyJWTAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: Errors verifying JWTs that have been been received by the token lambda.
+      AlarmDescription: !Sub
+        - "Errors verifying JWTs that have been been received by the token lambda. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
@@ -858,7 +864,9 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-${Environment}-SessionLambdaNoMatchingEncryptionKeyAlarm"
-      AlarmDescription: Failed to find a key alias to decrypt a given JWT payload.
+      AlarmDescription: !Sub
+        - "Failed to find a key alias to decrypt a given JWT payload. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
@@ -883,7 +891,9 @@ Resources:
   AddressAPIGW5XXErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: !Sub Address ${Environment} API Gateway 5XX errors
+      AlarmDescription: !Sub 
+        - "Address ${Environment} API Gateway 5XX errors. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic
@@ -1204,7 +1214,9 @@ Resources:
     Condition: DeployAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-${Environment}-JsonWebKeys5XXApiGwErrorAlarm"
-      AlarmDescription: !Sub "${AWS::StackName}-PublicAddressApi - There has been a small proportion of 5XX errors on the JsonWebKeys endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "${AWS::StackName}-PublicAddressApi - There has been a small proportion of 5XX errors on the JsonWebKeys endpoint. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
@@ -1265,7 +1277,9 @@ Resources:
     Condition: DeployAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-JsonWebKeys5XXApiGwErrorCriticalAlarm"
-      AlarmDescription: !Sub "${AWS::StackName}-PublicAddressApi - There has been a significant proportion of 5XX errors on the JsonWebKeys endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "${AWS::StackName}-PublicAddressApi - There has been a significant proportion of 5XX errors on the JsonWebKeys endpoint. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true
       OKActions:
         - !ImportValue core-infrastructure-AlarmTopic
@@ -1328,7 +1342,9 @@ Resources:
     Condition: DeployAlarms
     Properties:
       AlarmName: !Sub "${AWS::StackName}-JsonWebKeys4XXApiGwErrorAlarm"
-      AlarmDescription: !Sub "${AWS::StackName}-PublicAddressApi - There has been a small proportion of 4XX errors on the JsonWebKeys endpoint. ${SupportManualURL}"
+      AlarmDescription: !Sub
+        - "${AWS::StackName}-PublicAddressApi - There has been a small proportion of 4XX errors on the JsonWebKeys endpoint. Runbook: ${SupportManualURL}"
+        - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: false # alarm reviewed in production and decision made to disable
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Change SupportManualURL to mapping
- Add SupportManualURL to alarms where it wasn't present

### Why did it change

Because params can't be easily updated

### Screenshots

Before
<img width="1128" alt="image" src="https://github.com/user-attachments/assets/67d2bca3-285a-40ae-89a8-a6ab03144824" />

After



### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3214](https://govukverify.atlassian.net/browse/OJ-3214)


[OJ-3214]: https://govukverify.atlassian.net/browse/OJ-3214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ