### PR TITLE
OJ-3179: Turn JsonWebKeys4XXApiGwErrorAlarm on

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -1345,7 +1345,7 @@ Resources:
       AlarmDescription: !Sub
         - "${AWS::StackName}-PublicAddressApi - There has been a small proportion of 4XX errors on the JsonWebKeys endpoint. Runbook: ${SupportManualURL}"
         - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
-      ActionsEnabled: false # alarm reviewed in production and decision made to disable
+      ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Turn JsonWebKeys4XXApiGwErrorAlarm on

### Why did it change

As it is only a warning alarm it's safe to turn on

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3179](https://govukverify.atlassian.net/browse/OJ-3179)

[OJ-3179]: https://govukverify.atlassian.net/browse/OJ-3179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ