### PR TITLE
Tweak Session JWT verify critical alarm.

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -857,12 +857,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${AWS::StackName}-${Environment}-SessionLambdaFailedToVerifyJWTCriticalAlarm
       AlarmDescription: !Sub
-        - "Errors verifying JWTs (jwt_verification_failed) rate exceeds 80% of Session Lambda invocations consecutively for 3, 5 minute periods. Runbook: ${SupportManualURL}"
+        - "Errors verifying JWTs (jwt_verification_failed) rate exceeds 80% of Session Lambda invocations consecutively for 5, 5 minute periods. Runbook: ${SupportManualURL}"
         - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ComparisonOperator: GreaterThanThreshold
       Threshold: 80
-      DatapointsToAlarm: 3
-      EvaluationPeriods: 3
+      DatapointsToAlarm: 5
+      EvaluationPeriods: 5
       TreatMissingData: notBreaching
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic


### PR DESCRIPTION
## Proposed changes

### What changed

Increased evaluation periods from `3 of 3` to `5 of 5`.

### Why did it change

The alarm was very close to triggering last night due to expired JWTs. We do not want to trigger another pager duty for this. 

Increasing the evaluation periods for now, we can reduce this again once/if expired JWTs are no longer include in the metrics used for the alarm. 