### PR TITLE
OJ-2966: Change access token function to TS version

### DIFF
--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -154,7 +154,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-AccessTokenFunction:live/invocations
+          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-AccessTokenFunctionTS:live/invocations
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -927,8 +927,8 @@ Resources:
               Namespace: !Sub "${CriIdentifier}"
               MetricName: jwt_verification_failed
               Dimensions:
-                - Name: Service
-                  Value: !Sub "${CriIdentifier}-access-token"
+                - Name: service
+                  Value: !Sub "${CriIdentifier}-access-token-2"
             Period: 300
             Stat: Sum
         - Id: m2
@@ -939,7 +939,7 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${CommonStackName}-AccessTokenFunction
+                  Value: !Sub ${CommonStackName}-AccessTokenFunctionTS
             Period: 300
             Stat: Sum
 
@@ -974,8 +974,8 @@ Resources:
               Namespace: !Sub "${CriIdentifier}"
               MetricName: jwt_verification_failed
               Dimensions:
-                - Name: Service
-                  Value: !Sub "${CriIdentifier}-access-token"
+                - Name: service
+                  Value: !Sub "${CriIdentifier}-access-token-2"
             Period: 300
             Stat: Sum
         - Id: m2
@@ -986,7 +986,7 @@ Resources:
               MetricName: Invocations
               Dimensions:
                 - Name: FunctionName
-                  Value: !Sub ${CommonStackName}-AccessTokenFunction
+                  Value: !Sub ${CommonStackName}-AccessTokenFunctionTS
             Period: 300
             Stat: Sum
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Change access token function to TS version

### Why did it change

To increase consistency with other Orange CRIs

### Screenshots

Alarms still working

<img width="1154" height="565" alt="image" src="https://github.com/user-attachments/assets/522a1b4e-2fee-4082-8f0c-a255050cd66e" />
<img width="1147" height="568" alt="image" src="https://github.com/user-attachments/assets/93a1935f-b351-4b8e-a92e-a25f03e008cd" />


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2966](https://govukverify.atlassian.net/browse/OJ-2966)

[OJ-2966]: https://govukverify.atlassian.net/browse/OJ-2966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ