### PR TITLE
Revert "Tweak Session JWT verify critical alarm."

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -857,12 +857,12 @@ Resources:
     Properties:
       AlarmName: !Sub ${AWS::StackName}-${Environment}-SessionLambdaFailedToVerifyJWTCriticalAlarm
       AlarmDescription: !Sub
-        - "Errors verifying JWTs (jwt_verification_failed) rate exceeds 80% of Session Lambda invocations consecutively for 5, 5 minute periods. Runbook: ${SupportManualURL}"
+        - "Errors verifying JWTs (jwt_verification_failed) rate exceeds 80% of Session Lambda invocations consecutively for 3, 5 minute periods. Runbook: ${SupportManualURL}"
         - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ComparisonOperator: GreaterThanThreshold
       Threshold: 80
-      DatapointsToAlarm: 5
-      EvaluationPeriods: 5
+      DatapointsToAlarm: 3
+      EvaluationPeriods: 3
       TreatMissingData: notBreaching
       AlarmActions:
         - !ImportValue core-infrastructure-AlarmTopic


### PR DESCRIPTION
Reverts govuk-one-login/ipv-cri-address-api#1314

This change can now be reverted as expired JWTs are no longer included in the `jwt_verification_failed` metric. The original PR was a temporary change to increase the threshold to prevent the critical alarm alerting support again. 

Common-lambdas PR making this change: https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/530