### PR TITLE
OJ-3206: Store address entry type metric based on uprn presence

### DIFF
--- a/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
+++ b/lambdas/address/src/main/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandler.java
@@ -109,6 +109,8 @@ public class AddressHandler
                 // Save our addresses to the address table
                 addressService.saveAddresses(UUID.fromString(sessionId), addresses, addressTtl);
 
+                addressService.storeAddressEntryTypeMetric(eventProbe, addresses);
+
                 // Now we've saved our address, we need to create an authorization code for the
                 // session
                 sessionService.createAuthorizationCode(session);

--- a/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
+++ b/lambdas/address/src/test/java/uk/gov/di/ipv/cri/address/api/handler/AddressHandlerTest.java
@@ -114,6 +114,7 @@ class AddressHandlerTest {
 
         verify(mockSessionService).createAuthorizationCode(sessionItem);
         verify(mockAddressService).setAddressValidity(canonicalAddresses);
+        verify(mockAddressService).storeAddressEntryTypeMetric(eventProbe, canonicalAddresses);
         verify(eventProbe).log(Level.INFO, "found session");
         verify(eventProbe).counterMetric("address");
         verifyNoMoreInteractions(eventProbe);


### PR DESCRIPTION
## Proposed changes

### What changed

Added method to store an entry type metric for every address entered. This is based on if the UPRN is present on an address, this field is only present on addresses returned by the OS API and unmodified. The metrics are;
`manual-address-entry`
`pre-populated-address-entry`

### Why did it change

So we can track how many users are entering addresses manually versus using the pre--populated address from OS API.

### Issue tracking
- [OJ-3206](https://govukverify.atlassian.net/browse/OJ-3206)

### Screenshot

<img width="1633" height="516" alt="image" src="https://github.com/user-attachments/assets/68195985-39df-4da0-b264-7a3d97bb866f" />

[OJ-3206]: https://govukverify.atlassian.net/browse/OJ-3206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ