### PR TITLE
OJ-3313: Save Trimmed Postcode

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/address/api/service/VerifiableCredentialService.java
@@ -13,13 +13,13 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 import static com.nimbusds.jwt.JWTClaimNames.ISSUER;
 import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.ADDRESS_CREDENTIAL_TYPE;
 import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.DI_CONTEXT;
 import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.VC_ADDRESS_KEY;
 import static uk.gov.di.ipv.cri.address.api.domain.VerifiableCredentialConstants.W3_BASE_CONTEXT;
+import static uk.gov.di.ipv.cri.address.library.util.CountryCode.isGbAndCrownDependency;
 
 public class VerifiableCredentialService {
     private final VerifiableCredentialClaimsSetBuilder vcClaimsSetBuilder;
@@ -70,7 +70,7 @@ public class VerifiableCredentialService {
                 "addressesEntered",
                 Objects.nonNull(addresses) ? addresses.size() : 0,
                 "isUkAddress",
-                isUkAddress(getFirstAddressCountryCode(addresses)));
+                isGbAndCrownDependency(getFirstAddressCountryCode(addresses)));
     }
 
     private Object[] convertAddresses(List<CanonicalAddress> addresses) {
@@ -86,9 +86,5 @@ public class VerifiableCredentialService {
             return "";
         }
         return addresses.get(0).getAddressCountry();
-    }
-
-    private boolean isUkAddress(final String countryCode) {
-        return Stream.of("GB", "GG", "JE", "IM").anyMatch(countryCode::equalsIgnoreCase);
     }
 }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/service/AddressService.java
@@ -112,10 +112,7 @@ public class AddressService {
             int maxUKPostcodeLength = 7;
 
             if (postCodeLength >= minUKPostcodeLength && postCodeLength <= maxUKPostcodeLength) {
-                String outwardPostCodePart = formattedPostCode.substring(0, postCodeLength - 3);
-                String inwardPostCodeCodePart = formattedPostCode.substring(postCodeLength - 3);
-
-                address.setPostalCode(outwardPostCodePart + " " + inwardPostCodeCodePart);
+                address.setPostalCode(formattedPostCode);
             }
         }
         return address;

--- a/lib/src/main/java/uk/gov/di/ipv/cri/address/library/util/CountryCode.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/address/library/util/CountryCode.java
@@ -1,0 +1,26 @@
+package uk.gov.di.ipv.cri.address.library.util;
+
+import software.amazon.awssdk.utils.StringUtils;
+import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
+
+import java.util.List;
+import java.util.Set;
+
+public class CountryCode {
+
+    private CountryCode() {}
+
+    private static final Set<String> GB_AND_CROWN_DEPENDENCIES = Set.of("GB", "GG", "JE", "IM");
+
+    public static boolean isGreatBritain(final String code) {
+        return "GB".equalsIgnoreCase(code);
+    }
+
+    public static boolean isGbAndCrownDependency(final String code) {
+        return code != null && GB_AND_CROWN_DEPENDENCIES.contains(code.toUpperCase());
+    }
+
+    public static boolean isCountryCodeAbsentForAny(List<CanonicalAddress> addresses) {
+        return addresses.stream().anyMatch(a -> StringUtils.isEmpty(a.getAddressCountry()));
+    }
+}

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/service/AddressServiceTest.java
@@ -326,15 +326,15 @@ class AddressServiceTest {
 
         @ParameterizedTest
         @CsvSource({
-            "'M1 1AA', 'M1 1AA'", // correct
-            "'B33 8TH', 'B33 8TH'", // correct
-            "'W1A0AX', 'W1A 0AX'", // should add space
-            "'SE1 9GP', 'SE1 9GP'", // already correct
-            "' E1 6AN', 'E1 6AN'", // should remove leading space
-            "'N1 9GU ', 'N1 9GU'", // should remove trailing space
-            "' W2 1HB ', 'W2 1HB'", // should remove leading and trailing spaces
-            "'SW1A  2AA', 'SW1A 2AA'", // should normalize double space to single
-            "'   M25  4RT', 'M25 4RT'" // should remove leading spaces and normalize double space
+            "'M1 1AA', 'M11AA'", // correct
+            "'B33 8TH', 'B338TH'", // correct
+            "'W1A0AX', 'W1A0AX'", // correct
+            "'SE1 9GP', 'SE19GP'", // already correct
+            "' E1 6AN', 'E16AN'", // should remove leading space
+            "'N1 9GU ', 'N19GU'", // should remove trailing space
+            "' W2 1HB ', 'W21HB'", // should remove leading and trailing spaces
+            "'SW1A  2AA', 'SW1A2AA'", // should normalize double space to single
+            "'   M25  4RT', 'M254RT'" // should remove leading spaces and normalize double space
         })
         void normalizesPostCodeWithoutSpacesWhileSavingWhenGivenAddressesWithPostcodeSpaces(
                 String inputPostcode, String expectedPostcode) {

--- a/lib/src/test/java/uk/gov/di/ipv/cri/address/library/util/CountryCodeTest.java
+++ b/lib/src/test/java/uk/gov/di/ipv/cri/address/library/util/CountryCodeTest.java
@@ -1,0 +1,139 @@
+package uk.gov.di.ipv.cri.address.library.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.di.ipv.cri.common.library.persistence.item.CanonicalAddress;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CountryCodeTest {
+    @Nested
+    @DisplayName("isGreatBritain Tests")
+    class IsGreatBritainTests {
+        @ParameterizedTest(name = "Should return true for \"{0}\"")
+        @ValueSource(strings = {"GB", "gb", "Gb"})
+        @DisplayName("Returns true for valid GB variants")
+        void returnsTrueForGbAlternatives(String input) {
+            assertTrue(CountryCode.isGreatBritain(input));
+        }
+
+        @ParameterizedTest(name = "Should return false for \"{0}\"")
+        @ValueSource(strings = {"GG", "JE", "IM", "UK", "NI", "", " gb ", "GBR", "g"})
+        @DisplayName("Returns false for invalid or malformed inputs")
+        void returnsFalseWhenNonGbOrMalformed(String input) {
+            assertFalse(CountryCode.isGreatBritain(input));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @DisplayName("Returns false for null input")
+        void returnsFalseForNull(String input) {
+            assertFalse(CountryCode.isGreatBritain(input));
+        }
+    }
+
+    @Nested
+    @DisplayName("isGbAndCrownDependency Tests")
+    class IsGbAndCrownDependencyTests {
+        @ParameterizedTest(name = "Should return true for \"{0}\"")
+        @ValueSource(strings = {"GB", "gg", "Je", "im"})
+        @DisplayName("Returns true for valid GB and crown dependency codes")
+        void returnsTrueForValidCodes(String input) {
+            assertTrue(CountryCode.isGbAndCrownDependency(input));
+        }
+
+        @ParameterizedTest(name = "Should return false for \"{0}\"")
+        @ValueSource(strings = {"UK", "NI", "FR", "DE", "US", "", " gb ", "GBR", "g"})
+        @DisplayName("Returns false for invalid or malformed inputs")
+        void returnsFalseForInvalidCodes(String input) {
+            assertFalse(CountryCode.isGbAndCrownDependency(input));
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @DisplayName("Returns false for null input")
+        void returnsFalseForNull(String input) {
+            assertFalse(CountryCode.isGbAndCrownDependency(input));
+        }
+    }
+
+    @Nested
+    @DisplayName("isCountryCodeAbsentForAny Tests")
+    class IsCountryCodeAbsentForAnyTests {
+        @Test
+        @DisplayName("Returns false when all addresses have a valid country code")
+        void returnsFalseWhenAllCountryCodesArePresent() {
+            CanonicalAddress gb = new CanonicalAddress();
+            gb.setAddressCountry("GB");
+
+            CanonicalAddress je = new CanonicalAddress();
+            je.setAddressCountry("JE");
+
+            CanonicalAddress im = new CanonicalAddress();
+            im.setAddressCountry("IM");
+
+            assertFalse(CountryCode.isCountryCodeAbsentForAny(List.of(gb, je, im)));
+        }
+
+        @Test
+        @DisplayName("Returns true when at least one address has an empty country code")
+        void returnsTrueWhenOneCountryCodeIsMissing() {
+
+            CanonicalAddress gb = new CanonicalAddress();
+            gb.setAddressCountry("GB");
+
+            CanonicalAddress je = new CanonicalAddress();
+            je.setAddressCountry("");
+
+            CanonicalAddress im = new CanonicalAddress();
+            im.setAddressCountry("IM");
+
+            assertTrue(CountryCode.isCountryCodeAbsentForAny(List.of(gb, je, im)));
+        }
+
+        @Test
+        @DisplayName("Returns true when at least one address has a null country code")
+        void returnsTrueWhenOneCountryCodeIsNull() {
+
+            CanonicalAddress gb = new CanonicalAddress();
+            gb.setAddressCountry("GB");
+            CanonicalAddress je = new CanonicalAddress();
+            je.setAddressCountry(null);
+            CanonicalAddress im = new CanonicalAddress();
+            im.setAddressCountry("IM");
+
+            assertTrue(CountryCode.isCountryCodeAbsentForAny(List.of(gb, je, im)));
+        }
+
+        @Test
+        @DisplayName("Returns true when all addresses have empty or null country codes")
+        void returnsTrueWhenAllCountryCodesAreMissing() {
+            CanonicalAddress nullCountryCode = new CanonicalAddress();
+            nullCountryCode.setAddressCountry(null);
+
+            CanonicalAddress emptyCountryCode = new CanonicalAddress();
+            emptyCountryCode.setAddressCountry("");
+
+            assertTrue(
+                    CountryCode.isCountryCodeAbsentForAny(
+                            List.of(nullCountryCode, emptyCountryCode)));
+        }
+
+        @Test
+        @DisplayName(
+                "Returns false when the list is empty (no country codes are missing because none exist)")
+        void returnsFalseWhenAddressListIsEmpty() {
+            List<CanonicalAddress> addresses = Collections.emptyList();
+
+            assertFalse(CountryCode.isCountryCodeAbsentForAny(addresses));
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

DVLA has reported validation issues due to inconsistent formatting of postcodes, submitted via our address entry field this include  postcodes containing extra or irregular white spaces this is as expected see https://design-system.service.gov.uk/patterns/addresses/

However, when user has committed to address changes; the post code should be stored in a way as to prevent  reported validation issues

### What changed

Store postcode with any validation issues

**Postcode with trailing space and extra space in the middle**

<img width="548" height="412" alt="image" src="https://github.com/user-attachments/assets/2023840e-f95e-42fe-bbdc-ae30ee88f82c" />

<img width="631" height="492" alt="image" src="https://github.com/user-attachments/assets/9f0269d7-75f0-4e64-8927-5f8e2bd79923" />

<img width="529" height="748" alt="image" src="https://github.com/user-attachments/assets/50f47489-c9f7-4c89-9aca-d3f668aa0abe" />

<img width="768" height="488" alt="image" src="https://github.com/user-attachments/assets/14a2b095-8ca2-44a9-90d3-001793023f82" />

**Click on Change link**

<img width="548" height="418" alt="image" src="https://github.com/user-attachments/assets/3707df7e-903b-4c66-b6c7-a518ffdd52ef" />

**Confirm your details appear like this**
<img width="619" height="510" alt="image" src="https://github.com/user-attachments/assets/e5516f42-55b2-4c98-afe8-d576048a8654" />

**Click on all change link reveals - post code is still with spaces**
<img width="511" height="378" alt="image" src="https://github.com/user-attachments/assets/b12a3d85-d8d3-4a94-90c7-3c287ae4c259" />

Postcode in dynamodb is with spaces

<img width="986" height="296" alt="image" src="https://github.com/user-attachments/assets/f0db5e42-4da2-419c-8ad1-fa444be8bba3" />

**NB:**
Added a scenario in `AddressAPIHappyPath.feature` called `uk_address_save_address_remove_spaces_from_postcode`
This implements a manual UK address flow i.e. UK postcode with spaces has been manually entered. This test saving addresses with different passcode values with spaces and compares the postcode retrieved in the generated VC output with the expected (non spaced) postcode from the specified example see below

<img width="1377" height="264" alt="image" src="https://github.com/user-attachments/assets/41a1b17d-1538-4412-ae97-826e710aec2f" />

**DVLA** is for England so -> Guernsey, Jersey and Isle of Man are out of scope
### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3313](https://govukverify.atlassian.net/browse/OJ-3313)



[OJ-3313]: https://govukverify.atlassian.net/browse/OJ-3313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ