### PR TITLE
OJ-3274: Add OS API URL SSM params per client

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/package-for-build.yml
+++ b/.github/workflows/package-for-build.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
 
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/package-for-dev.yml
+++ b/.github/workflows/package-for-dev.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
 
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
 
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/run-pact-tests.yml
+++ b/.github/workflows/run-pact-tests.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/run-unit-tests-java.yml
+++ b/.github/workflows/run-unit-tests-java.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -56,6 +56,7 @@ Conditions:
   IsLocalDevEnvironment: !Equals [!Ref Environment, localdev]
   IsBuildEnvironment: !Equals [!Ref Environment, build]
   IsProdEnvironment: !Equals [!Ref Environment, production]
+  IsNotProdEnvironment: !Not [!Equals [!Ref Environment, production]]
   IsNotDevEnvironment: !Not [!Condition IsDevEnvironment]
   IsDevLikeOrBuild: !Or
     - !Condition IsDevEnvironment
@@ -190,6 +191,15 @@ Mappings:
   StaticVariables:
     Urls:
       SupportManualURL: "https://team-manual.account.gov.uk/teams/CRI-Orange-team/supporting-cri-orange/address-credential-issuer-runbook"
+      OrdnanceSurveyAPIURL: "https://api.os.uk/search/places/v1/postcode"
+
+  StubOrdnanceSurveyAPIURLs:
+    Environment:
+      localdev: https://dvzu1fes9j.execute-api.eu-west-2.amazonaws.com/dev/search/places/v1/postcode
+      dev: https://dvzu1fes9j.execute-api.eu-west-2.amazonaws.com/dev/search/places/v1/postcode
+      build: https://b8ysflv2t2.execute-api.eu-west-2.amazonaws.com/build/search/places/v1/postcode
+      staging: https://hv21rikq99.execute-api.eu-west-2.amazonaws.com/staging/search/places/v1/postcode
+      integration: https://api.os.uk/search/places/v1/postcode
 
   MemorySizeMapping:
     Environment:
@@ -752,6 +762,110 @@ Resources:
       Value:
         !FindInMap [VcContainsUniqueIdMapping, Environment, !Ref Environment]
       Description: Verifiable Credential Contains UniqueId Mapping
+
+  ProdIpvCoreOrdnanceSurveyAPIURL:
+    Condition: IsProdEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core"
+      Type: String
+      Value: !FindInMap [StaticVariables, Urls, OrdnanceSurveyAPIURL]
+
+  ProdIpvCoreStubPreProdOrdnanceSurveyAPIURL:
+    Condition: IsProdEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core-stub-pre-prod"
+      Type: String
+      Value: !FindInMap [StaticVariables, Urls, OrdnanceSurveyAPIURL]
+
+  ProdIpvCoreStubPreProdAwsBuildOrdnanceSurveyAPIURL:
+    Condition: IsProdEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core-stub-pre-prod-aws-build"
+      Type: String
+      Value: !FindInMap [StaticVariables, Urls, OrdnanceSurveyAPIURL]
+
+  IpvCoreStubAwsProdOrdnanceSurveyAPIURL:
+    Condition: IsNotProdEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core-stub-aws-prod"
+      Type: String
+      Value: !FindInMap [ StubOrdnanceSurveyAPIURLs, Environment, !Ref Environment ]
+
+  IpvCoreStubAwsBuildOrdnanceSurveyAPIURL:
+    Condition: IsNotProdEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core-stub-aws-build"
+      Type: String
+      Value: !FindInMap [ StubOrdnanceSurveyAPIURLs, Environment, !Ref Environment ]
+
+  IpvCoreStubOrdnanceSurveyAPIURL:
+    Condition: IsNotProdEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core-stub"
+      Type: String
+      Value: !FindInMap [ StubOrdnanceSurveyAPIURLs, Environment, !Ref Environment ]
+
+  IpvCoreStubPreProdAwsBuildOrdnanceSurveyAPIURL:
+    Condition: IsNotProdEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core-stub-pre-prod-aws-build"
+      Type: String
+      Value: !FindInMap [StaticVariables, Urls, OrdnanceSurveyAPIURL]
+
+  IpvCoreStubPreProdOrdnanceSurveyAPIURL:
+    Condition: IsNotProdEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core-stub-pre-prod"
+      Type: String
+      Value: !FindInMap [StaticVariables, Urls, OrdnanceSurveyAPIURL]
+
+  IpvCoreStubAwsHeadlessOrdnanceSurveyAPIURL:
+    Condition: IsNotProdEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core-stub-aws-headless"
+      Type: String
+      Value: !FindInMap [ StubOrdnanceSurveyAPIURLs, Environment, !Ref Environment ]
+
+  IpvCoreStubAwsProd3rdpartyOrdnanceSurveyAPIURL:
+    Condition: IsNotProdEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core-stub-aws-prod_3rdparty"
+      Type: String
+      Value: !FindInMap [StaticVariables, Urls, OrdnanceSurveyAPIURL]
+
+  IpvCoreStubAwsBuild3rdpartyOrdnanceSurveyAPIURL:
+    Condition: IsNotProdEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core-stub-aws-build_3rdparty"
+      Type: String
+      Value: !FindInMap [StaticVariables, Urls, OrdnanceSurveyAPIURL]
+
+  IpvCoreOrdnanceSurveyAPIURL:
+    Condition: IsNotProdEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core"
+      Type: String
+      Value: !FindInMap [ StubOrdnanceSurveyAPIURLs, Environment, !Ref Environment ]
+
+  IpvCore3rdPartyStubsOrdnanceSurveyAPIURL:
+    Condition: IsNotProdEnvironment
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core-3rd-party-stubs"
+      Type: String
+      Value: !FindInMap [StaticVariables, Urls, OrdnanceSurveyAPIURL]
 
   PostcodeLookupFunctionPermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
## Proposed changes

### What changed

Adds Ordnance Survery API URL SSM params for different clients, example SSM param name: `"/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core"`

Fixed gradle version issue in GHA's, original KBV PR here: https://github.com/govuk-one-login/ipv-cri-kbv-api/pull/534

### Why did it change

Create the SSM params to allow (in future PRs) Core and other consumers to dynamically configure whether the stub or real API should be used, depending on the Client ID provided 

### Issue tracking

- [OJ-3274](https://govukverify.atlassian.net/browse/OJ-3274)

[OJ-3274]: https://govukverify.atlassian.net/browse/OJ-3274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ