### PR TITLE
fix: Pin gradle version in GHAs, using wrapper failed post-merge actions

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: wrapper
+          gradle-version: '8.13'
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/package-for-build.yml
+++ b/.github/workflows/package-for-build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: wrapper
+          gradle-version: '8.13'
 
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/package-for-dev.yml
+++ b/.github/workflows/package-for-dev.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: wrapper
+          gradle-version: '8.13'
 
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: wrapper
+          gradle-version: '8.13'
 
       - name: Assume AWS Role
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/run-pact-tests.yml
+++ b/.github/workflows/run-pact-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: wrapper
+          gradle-version: '8.13'
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/run-unit-tests-java.yml
+++ b/.github/workflows/run-unit-tests-java.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: wrapper
+          gradle-version: '8.13'
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: wrapper
+          gradle-version: '8.13'
 
       - name: Set up JDK
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Proposed changes

### What changed

Pin gradle version to specific version in GHAs

### Why did it change

The doc's imply wrapper should work, but it failed post merge and used gradle 9 (https://github.com/govuk-one-login/ipv-cri-address-api/actions/runs/16908954673). So switching to hardcoding the version.

PR initially added: https://github.com/govuk-one-login/ipv-cri-address-api/pull/1327