### PR TITLE
OJ-3277: Remove global OrdnanceSurveyAPIURL ssm param

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -54,14 +54,9 @@ Conditions:
   IsDevEnvironment:
     !Or [!Equals [!Ref Environment, dev], !Condition IsLocalDevEnvironment]
   IsLocalDevEnvironment: !Equals [!Ref Environment, localdev]
-  IsBuildEnvironment: !Equals [!Ref Environment, build]
   IsProdEnvironment: !Equals [!Ref Environment, production]
   IsNotProdEnvironment: !Not [!Equals [!Ref Environment, production]]
   IsNotDevEnvironment: !Not [!Condition IsDevEnvironment]
-  IsDevLikeOrBuild: !Or
-    - !Condition IsDevEnvironment
-    - !Condition IsLocalDevEnvironment
-    - !Condition IsBuildEnvironment
   AddProvisionedConcurrency:
     !Not [
       !Equals [
@@ -397,7 +392,6 @@ Resources:
               Action:
                 - ssm:GetParameter
               Resource:
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/OrdnanceSurveyAPIURL"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/OrdnanceSurveyAPIUrl/*"
         - Statement:
             - Effect: Allow
@@ -731,21 +725,6 @@ Resources:
       Type: String
       Value: !FindInMap [JwtTtlUnitMapping, Environment, !Ref Environment]
       Description: The unit for the time-to-live for an JWT e.g. (MONTHS)
-
-  OrdnanceSurveyAPIURLParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIURL"
-      Type: String
-      Value: !Sub
-        - "${Domain}/search/places/v1/postcode"
-        - Domain:
-            !If [
-              IsDevLikeOrBuild,
-              !ImportValue third-party-stubs-ImposterStubApiUrl,
-              "https://api.os.uk",
-            ]
-      Description: Ordnance Survey Postcode Lookup API URL
 
   AddressLookupTableNameParameter:
     Type: AWS::SSM::Parameter


### PR DESCRIPTION
## Proposed changes

### What changed

Removed `/${AWS::StackName}/OrdnanceSurveyAPIURL` SSM param
Removed `IsDevLikeOrBuild` & `IsBuildEnvironment` as no longer used.

### Why did it change

Now that we no longer use the original global `OrdnanceSurveyAPIURL` SSM param, we can remove it.

Client specific OrdnanceSurveyAPIURL params started being used here: https://github.com/govuk-one-login/ipv-cri-address-api/pull/1332 

### Issue tracking
- [OJ-3277](https://govukverify.atlassian.net/browse/OJ-3277)

[OJ-3277]: https://govukverify.atlassian.net/browse/OJ-3277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ