### PR TITLE
OJ-3115: Reject dates on address endpoint with year 0000

### DIFF
--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -391,12 +391,14 @@ components:
           example: "IL"
           description: "The state, district, county, parish or province"
         validFrom:
-          description: "Date in ISO 8601 format"
+          description: "Date in ISO 8601 format, year must not be 0000"
           type: "string"
+          pattern: "^(?!0000)\\d{4}-\\d{2}-\\d{2}$"
           example: "2020-01-01"
         validUntil:
-          description: "Date in ISO 8601 format"
+          description: "Date in ISO 8601 format, year must not be 0000"
           type: "string"
+          pattern: "^(?!0000)\\d{4}-\\d{2}-\\d{2}$"
           example: "2020-01-01"
   responses:
     Error400:

--- a/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/client/AddressApiClient.java
@@ -62,6 +62,11 @@ public class AddressApiClient {
                         .build());
     }
 
+    public HttpResponse<String> sendAddressRequest(String sessionId, String requestBody)
+            throws IOException, InterruptedException {
+        return sendAddressRequestWithBody(sessionId, requestBody);
+    }
+
     public HttpResponse<String> sendAddressRequest(String sessionId, AddressContext addressContext)
             throws IOException, InterruptedException {
         CanonicalAddress currentAddress =

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -437,6 +437,13 @@ public class AddressSteps {
         assertEquals("\"Missing postcode in request body.\"", responseBody);
     }
 
+    @Then("the response body contains bad request error")
+    public void theResponseBodyContainsBadRequestError() {
+        var responseBody = this.testContext.getResponse().body();
+        assertNotNull(responseBody);
+        assertEquals("{\"message\": \"Invalid request body\"}", responseBody);
+    }
+
     @Then("the IPV_ADDRESS_CRI_END event is emitted and validated against schema")
     public void verifyIpvAddressCriEndEventIsEmitted() throws IOException {
         String responseBody = testContext.getTestHarnessResponseBody();
@@ -476,6 +483,17 @@ public class AddressSteps {
                         addressContext.getUprn(),
                         addressContext.getPostcode(),
                         addressContext.getCountryCode()));
+    }
+
+    @Given("a request is made to the address endpoint with a validFrom date of {string}")
+    public void aRequestIsMadeToTheAddressEndpointWithDate(String validFromDate)
+            throws IOException, InterruptedException {
+        String requestBody =
+                "[{\"uprn\":100000000000,\"buildingNumber\":\"10\",\"streetName\":\"street\",\"addressLocality\":\"City\",\"postalCode\":\"SW1A 2AA\",\"addressCountry\":\"GB\",\"validFrom\":\""
+                        + validFromDate
+                        + "\"}]";
+        this.testContext.setResponse(
+                this.addressApiClient.sendAddressRequest("doesNotMatter", requestBody));
     }
 
     private void enterAddressFromDataTable(DataTable dataTable)

--- a/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
+++ b/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
@@ -41,3 +41,27 @@ Feature: Address API unhappy path test
     Given a request is made to the postcode-lookup endpoint without a postcode in the body and with session id in the header
     Then the endpoint should return a 400 HTTP status code
     And the response body contains no postcode error
+
+  @invalid_date
+  Scenario: Date in the request body is the invalid value 0000-01-01
+    Given a request is made to the address endpoint with a validFrom date of "0000-01-01"
+    Then the endpoint should return a 400 HTTP status code
+    And the response body contains bad request error
+
+  @invalid_date
+  Scenario: Date in the request body is the invalid value 20000-01-01
+    Given a request is made to the address endpoint with a validFrom date of "20000-01-01"
+    Then the endpoint should return a 400 HTTP status code
+    And the response body contains bad request error
+
+  @invalid_date
+  Scenario: Date in the request body is the invalid value 2000-one-one
+    Given a request is made to the address endpoint with a validFrom date of "2000-one-one"
+    Then the endpoint should return a 400 HTTP status code
+    And the response body contains bad request error
+
+  @invalid_date
+  Scenario: Date in the request body is the invalid value 01-01-2000
+    Given a request is made to the address endpoint with a validFrom date of "01-01-2000"
+    Then the endpoint should return a 400 HTTP status code
+    And the response body contains bad request error


### PR DESCRIPTION
## Proposed changes

### What changed

Adds regex to reject `0000` as the date year for `validFrom` and `validTo` in the API Address schema. 
Added an integration test to test this.

### Why did it change

If a request is sent to our `/address` with a `validFrom` or `validUntil` year of `0000` the deserialisation will error as LocalDate does not see `0000` as a valid date year. 

We have implemented a fix FE https://github.com/govuk-one-login/ipv-cri-address-front/pull/1209 but we also want to harden our endpoint to prevent `0000` causing `5XX` errors.

### Issue tracking

- [OJ-3115](https://govukverify.atlassian.net/browse/OJ-3115)


[OJ-3115]: https://govukverify.atlassian.net/browse/OJ-3115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ