### PR TITLE
OJ-3394: Hard code dynatrace layer version to 1.311

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -356,14 +356,8 @@ Resources:
             ]
           - [!Ref AWS::NoValue]
       Layers:
-        - !Sub
-          - "{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}"
-          - SecretArn:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                dynatraceSecretArn,
-              ]
+        # SEE https://github.com/govuk-one-login/observability-infrastructure/tree/main/lambdalayer
+        - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-postcode-lookup"


### PR DESCRIPTION
## Proposed changes

Explicitly specify the arn of the Dynatrace layer, hard coding for the **FIRST TIME** requires version with 1_311


### Why did it change

There’s a bug in the {{resolve:secretsmanager}} syntax that prevents the current configuration from deploying the latest available Dynatrace layer.


- [OJ-3394](https://govukverify.atlassian.net/browse/OJ-3394)


### After hard coding

<img width="1142" height="756" alt="image" src="https://github.com/user-attachments/assets/a861109e-baa7-4b51-b0f4-2c7f572d850e" />




### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3394]: https://govukverify.atlassian.net/browse/OJ-3394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ