### PR TITLE
OJ-3394: Update Dynatrace to version 1_313

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -357,7 +357,7 @@ Resources:
           - [!Ref AWS::NoValue]
       Layers:
         # SEE https://github.com/govuk-one-login/observability-infrastructure/tree/main/lambdalayer
-        - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
+        - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_313_36_20250507-184408_with_collector_java:1
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-postcode-lookup"


### PR DESCRIPTION
## Proposed changes

Update dynatrace layer to version 1_313

### What changed

The [previous PR](https://github.com/govuk-one-login/ipv-cri-address-api/pull/1338) has been merged 

### Why did it change

There is a more up to date version of dynatrace layer 

- [OJ-3394](https://govukverify.atlassian.net/browse/OJ-3394)

## Checklists

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks