### PR TITLE
OJ-3394: Hard code the other individual function layers

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -443,14 +443,7 @@ Resources:
             ]
           - [!Ref AWS::NoValue]
       Layers:
-        - !Sub
-          - "{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}"
-          - SecretArn:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                dynatraceSecretArn,
-              ]
+        - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_277_157_20231019-162516_with_collector_java:1
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-address"
@@ -507,14 +500,7 @@ Resources:
           - [!Ref AWS::NoValue]
       CodeUri: ../../lambdas/issuecredential
       Layers:
-        - !Sub
-          - "{{resolve:secretsmanager:${SecretArn}:SecretString:JAVA_LAYER}}"
-          - SecretArn:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                dynatraceSecretArn,
-              ]
+        - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_277_157_20231019-162516_with_collector_java:1
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-issuecredential"
@@ -586,14 +572,7 @@ Resources:
       CodeUri: ../../lambdas/get-addresses/
       Runtime: nodejs22.x
       Layers:
-        - !Sub
-          - "{{resolve:secretsmanager:${SecretArn}:SecretString:NODEJS_LAYER}}"
-          - SecretArn:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                dynatraceSecretArn,
-              ]
+        - arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_299_2_20240809-044254_with_collector_nodejs:2
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-get-addresses"


### PR DESCRIPTION
## Proposed changes

In this [PR](https://github.com/govuk-one-login/ipv-cri-address-api/pull/1338) I didn't notice that the Layer wasn't **global**
therefore only **PostcodeLookupFunction** has up to date dynatrace layer - since I have also merged the [following](https://github.com/govuk-one-login/ipv-cri-address-api/pull/1339)

This PR updates the other function layers to there corresponding values in AWS as the **FIRST** phase of hard coding

Subsequent PR will update to the latest

see: below screen shots

**DONE** - **PostcodeLookupFunction**
<img width="1629" height="363" alt="image" src="https://github.com/user-attachments/assets/160cc18a-ab36-479a-aa95-f0693337381c" />

This PR requires **FIRST PHASE UPDATE** from the old dynamic approach

**AddressFunction**
<img width="1606" height="334" alt="image" src="https://github.com/user-attachments/assets/20a79e31-4edc-4bad-b36b-85aa489b6e10" />
**GetAddressFunction**
<img width="1601" height="330" alt="image" src="https://github.com/user-attachments/assets/efb23571-0b13-4b51-9b10-b8ba14e9526a" />
**IssuecredentialFunction**
<img width="1620" height="357" alt="image" src="https://github.com/user-attachments/assets/9dcb4f05-a791-449b-9f01-74f5ef4e9d51" />

### Issue tracking

- [OJ-3394](https://govukverify.atlassian.net/browse/OJ-3394)


- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3394]: https://govukverify.atlassian.net/browse/OJ-3394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ