### PR TITLE
OJ-3439: Fix dependabot issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ subprojects {
 	}
 
 	dependencies {
-		implementation platform("software.amazon.awssdk:bom:2.26.20")
+		implementation platform("software.amazon.awssdk:bom:2.33.9")
 		implementation platform("com.fasterxml.jackson:jackson-bom:2.18.3")
 		implementation(libs.bundles.otel)
 	}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,18 @@
 [versions]
 aws-lambda-events = "3.11.0"
-nimbusds-oauth = "11.2"
-nimbusds-jwt = "9.40"
+nimbusds-oauth = "11.29.1"
+nimbusds-jwt = "10.5"
 junit = "5.10.3"
 mockito = "5.18.0"
 powertools = "1.18.0"
-cri-common-lib = "6.5.0"
+cri-common-lib = "6.6.0"
 pact-provider = "4.5.11"
 webcompere = "2.1.6"
 open-telemetry = "2.12.0-alpha"
 slf4j = "2.0.13"
 
 # Plugins
-spotless = "6.23.+"
+spotless = "8.0.+"
 sonarqube = "4.4.+"
 post-compile-weaving = "6.3.0"
 


### PR DESCRIPTION
## Proposed changes

### What changed

- Updated the version for `aws-bom` and `nimbusdus-oauth` to fix the issues raised by dependabot. Updated the main dependencies to fix the transitive dependencies listed [here](https://github.com/govuk-one-login/ipv-cri-address-api/security/dependabot)
- Updated `common-lib` and `spotless` dependency to latest as well.

N.B: unable to upgrade `powertools` dependency to the latest as it removes the `org.apache.logging.log4j` imports. When using the `slf4j logger` imports in replace of this, the `couldn't find aspectjrt.jar on classpath` error kept appearing due to having this `aspect libs.bundles.powertools` within the build.gradle file. Unable to update au.com.dius.pact:provider dependency as the vulnerability is still in the latest release [here](https://mvnrepository.com/artifact/au.com.dius.pact/provider). No latest version for org.apache.cxf:cxf-rt-frontend-jaxws dependency [here](https://mvnrepository.com/artifact/org.apache.cxf/cxf-rt-frontend-jaxws).

### Why did it change

To resolve dependabot issues.

### Issue tracking

- [OJ-3439](https://govukverify.atlassian.net/browse/OJ-3439)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3439]: https://govukverify.atlassian.net/browse/OJ-3439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ