### PR TITLE
OJ-3444: Conditionally include FMSRegionalPolicy

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -57,6 +57,8 @@ Conditions:
   IsProdEnvironment: !Equals [!Ref Environment, production]
   IsNotProdEnvironment: !Not [!Equals [!Ref Environment, production]]
   IsNotDevEnvironment: !Not [!Condition IsDevEnvironment]
+  IsNotIntOrProdEnvironment: !Not [!Or [!Equals [!Ref Environment, integration], !Equals [!Ref Environment, production]]]
+
   AddProvisionedConcurrency:
     !Not [
       !Equals [
@@ -254,6 +256,7 @@ Mappings:
       production: MONTHS
       localdev: HOURS
 
+
 Resources:
   PublicAddressApi:
     Type: AWS::Serverless::Api
@@ -261,6 +264,7 @@ Resources:
       Name: !Sub ${AWS::StackName}-PublicAddressApi
       Description: Public Address CRI API
       StageName: !Ref Environment
+      AlwaysDeploy: true
       AccessLogSetting:
         DestinationArn: !GetAtt PublicAddressApiAccessLogGroup.Arn
       DefinitionBody:
@@ -274,6 +278,9 @@ Resources:
             Location: ./public-api.yaml
       EndpointConfiguration:
         Type: REGIONAL
+      Tags:
+        FMSRegionalPolicy: !If [IsNotIntOrProdEnvironment, "false", ""]
+        CustomPolicy: !If [IsNotIntOrProdEnvironment, "true", ""]
 
   PrivateAddressApi:
     Type: AWS::Serverless::Api
@@ -281,6 +288,7 @@ Resources:
       Name: !Sub ${AWS::StackName}-PrivateAddressApi
       Description: Private Address CRI API
       StageName: !Ref Environment
+      AlwaysDeploy: true
       AccessLogSetting:
         DestinationArn: !GetAtt PrivateAddressApiAccessLogGroup.Arn
       DefinitionBody:
@@ -312,6 +320,11 @@ Resources:
                 Condition:
                   StringNotEquals:
                     aws:SourceVpce: !ImportValue cri-vpc-ApiGatewayVpcEndpointId
+      Tags:
+        FMSRegionalPolicy: !If [IsNotIntOrProdEnvironment, "false", ""]
+        CustomPolicy: !If [IsNotIntOrProdEnvironment, "true", ""]
+
+
 
   PublicAddressApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1088,7 +1101,7 @@ Resources:
   AddressAPIGW5XXErrors:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: !Sub 
+      AlarmDescription: !Sub
         - "Address ${Environment} API Gateway 5XX errors. Runbook: ${SupportManualURL}"
         - SupportManualURL: !FindInMap [StaticVariables, Urls, SupportManualURL]
       ActionsEnabled: true


### PR DESCRIPTION
## Proposed changes

As part of transitioning FMS WAF rule enforcement from COUNT to BLOCK, Security have set up custom policies for us to apply to our resources in scope. In COUNT mode FMS merely logs the rule violations, in BLOCK mode violating requests are actively blocked. 

The tags to implement this should only apply (conditionally) to resources deployed to dev, build and staging accounts. The tags must not apply to int and prod (there is a follow-up ticket for this:

### What changed

Apply tagging conditional to meet the above requirement

### Why did it change

Part of transitioning FMS WAF rule enforcement

**Tags on ApiGateway**
<img width="1025" height="733" alt="image" src="https://github.com/user-attachments/assets/b8cdb628-e5fb-410e-bab7-1ec444b26370" />


### Issue tracking

- [OJ-3444](https://govukverify.atlassian.net/browse/OJ-3444)

[OJ-3444]: https://govukverify.atlassian.net/browse/OJ-3444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ