### PR TITLE
OJ-3462: Add param to force localdev lambdas to update when env var c…

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -66,6 +66,10 @@ jobs:
       stack-name: ${{ steps.deploy.outputs.stack-name }}
       stack-outputs: ${{ steps.deploy.outputs.stack-outputs }}
     steps:
+      - name: Set timestamp
+        id: set_timestamp
+        run: echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
+
       - name: Deploy stack
         uses: govuk-one-login/github-actions/sam/deploy-stack@d201191485b645ec856a34e5ca48636cf97b2574
         id: deploy
@@ -86,3 +90,4 @@ jobs:
           parameters: |
             Environment=localdev
             SecretPrefix=pre-merge-test
+            ForceLambdaUpdate=${{ steps.set_timestamp.outputs.timestamp }}

--- a/deploy.sh
+++ b/deploy.sh
@@ -33,4 +33,5 @@ sam deploy --stack-name "$stack_name" \
   Environment=localdev \
   SecretPrefix=pre-merge-test \
   ${common_stack_name:+CommonStackName=$common_stack_name} \
-  ${secret_prefix:+SecretPrefix=$secret_prefix}
+  ${secret_prefix:+SecretPrefix=$secret_prefix} \
+  ForceLambdaUpdate="$(date +%s)"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -16,6 +16,10 @@ Parameters:
     Description: "Specifies the configuration to enable gradual Lambda deployments"
     Type: String
     Default: AllAtOnce
+  ForceLambdaUpdate:
+    Type: String
+    Default: "initial"
+    Description: "For localdev only - used to force Lambda version updates"
   CodeSigningConfigArn:
     Description: "The ARN of the Code Signing Config to use, provided by the deployment pipeline"
     Type: String
@@ -107,6 +111,7 @@ Globals:
         POWERTOOLS_LOG_LEVEL: INFO
         AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+        FORCE_LAMBDA_UPDATE: !If [IsLocalDevEnvironment, !Ref ForceLambdaUpdate, !Ref AWS::NoValue]
         DT_CONNECTION_AUTH_TOKEN: !Sub
           - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_AUTH_TOKEN}}"
           - SecretArn:


### PR DESCRIPTION
## Proposed changes

### What changed

Add `ForceLambdaUpdate` CF param and env var that can be used to force sam deployed (localdev) stacks to deploy new lambda versions if an env var changes.

### Why did it change

With moving to resolving SSM Params at deploy time and passing them directly into our Lambda functions as environment variables, when deploying using Sam (local or pre-merge GHA) sometimes the small changes (e.g. an env var) do not publish new Lambda versions for Java lambdas. This can cause deployment issues.

### Issue tracking
- [OJ-3462](https://govukverify.atlassian.net/browse/OJ-3462)


[OJ-3462]: https://govukverify.atlassian.net/browse/OJ-3462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ