### PR TITLE
chore(sonar): return value instead of promise.resolve

### DIFF
--- a/lambdas/get-addresses/src/get-addresses-handler.ts
+++ b/lambdas/get-addresses/src/get-addresses-handler.ts
@@ -18,7 +18,7 @@ export class AddressesHandler implements LambdaInterface {
 
             const result = await this.addressService.getAddressesBySessionId(sessionId);
 
-            return Promise.resolve({ statusCode: 200, body: JSON.stringify(result) });
+            return { statusCode: 200, body: JSON.stringify(result) };
         } catch (error: unknown) {
             return handleError(logger, error as Error, `Error in ${context.functionName}`);
         }


### PR DESCRIPTION
## Proposed changes

### What changed
Return the value in AddressesHandler as opposed to using Promise.resolve as async function automatically wraps whatever you return in a promise.

### Issue tracking
- [OJ-3566](https://govukverify.atlassian.net/browse/OJ-3566)


[OJ-3566]: https://govukverify.atlassian.net/browse/OJ-3566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ