### PR TITLE
OJ-3596: Output common/oauth stack name into SSM param for test resources

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -64,6 +64,9 @@ Conditions:
   IsDevBuildEnvironment:
     !Or [!Equals [!Ref Environment, build], !Condition IsDevEnvironment]
   IsNotDevBuildEnvironment: !Not [!Condition IsDevBuildEnvironment]
+  CreateOAuthSSMParam: !And
+    - !Not [!Condition IsLocalDevEnvironment]
+    - !Not [!Condition IsProdEnvironment]
 
   AddProvisionedConcurrency:
     !Not [
@@ -854,6 +857,15 @@ Resources:
       Name: !Sub "/${AWS::StackName}/OrdnanceSurveyAPIUrl/ipv-core-3rd-party-stubs"
       Type: String
       Value: !FindInMap [StaticVariables, Urls, OrdnanceSurveyAPIURL]
+
+  OAuthCommonStackNameParam:
+    Type: AWS::SSM::Parameter
+    Condition: CreateOAuthSSMParam
+    Properties:
+      Name: /common-cri/oauth-common/stack-name
+      Type: String
+      Value: !Ref CommonStackName
+      Description: The stack currently used for OAuth (common-lambdas or oauth-common). Only required for test-resources.
 
   PostcodeLookupFunctionPermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
## Proposed changes

### What changed

Added the SSM param `OAuthCommonStackNameParam`

### Why did it change

The test-resources stack needs to be able to reference resources in the OAuth Common stack, which currently hard-codes CommonStackName to `common-cri-api`.

### Issue tracking

- [OJ-3596](https://govukverify.atlassian.net/browse/OJ-3596)


[OJ-3596]: https://govukverify.atlassian.net/browse/OJ-3596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ