### PR TITLE
feat: use header to auth with OS API instead of query string parameter

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -124,7 +124,8 @@
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\\.eyJzdWIiOiJ0dCIsImlhdCI6MTUxNjIzOTAyMn0\\..*",
         "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
         "E9ZzuOoqcVU4pVB9rpmTzezjyOPRlOmPGJHKi8RSlIM",
-        "KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04"
+        "KlTMZthHZUkYz5AleTQ8jff0TJiS3q2OB9L5Fw4xA04",
+        "mock-api-key"
       ]
     }
   ],

--- a/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupService.java
+++ b/lambdas/postcode-lookup/src/main/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupService.java
@@ -147,12 +147,12 @@ public class PostcodeLookupService {
                                     .appendRawQueryParameter(
                                             "postcode",
                                             URLDecoder.decode(postcode, Charset.defaultCharset()))
-                                    .appendRawQueryParameter("key", apiKey)
                                     .method(SdkHttpMethod.GET)
                                     .build()
                                     .getUri())
                     .timeout(Duration.ofSeconds(CONNECTION_TIMEOUT_SECONDS))
                     .header("Accept", "application/json")
+                    .header("key", apiKey)
                     .GET()
                     .build();
         } catch (URISyntaxException e) {

--- a/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
+++ b/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
@@ -52,6 +52,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class PostcodeLookupServiceTest {
     private static final String TEST_CLIENT_ID = "mock-client-id";
+    private static final String TEST_API_KEY = "mock-api-key";
 
     @Mock private ConfigurationService mockConfigurationService;
     @Mock private HttpResponse<String> mockResponse;
@@ -73,6 +74,8 @@ class PostcodeLookupServiceTest {
 
     @Test
     void shouldLogAPILatency() throws IOException, InterruptedException {
+        when(mockConfigurationService.getSecretValue("OrdnanceSurveyAPIKey"))
+                .thenReturn(TEST_API_KEY);
         when(mockConfigurationService.getParameterValue("OrdnanceSurveyAPIUrl/" + TEST_CLIENT_ID))
                 .thenReturn("http://localhost:8080/");
         when(mockResponse.statusCode()).thenReturn(HttpStatusCode.OK);
@@ -118,6 +121,9 @@ class PostcodeLookupServiceTest {
         @Test
         void shouldThrowTimeoutExceptionWhenHttpRequestExceedsSetTimeout()
                 throws PostcodeLookupTimeoutException, IOException, InterruptedException {
+            when(mockConfigurationService.getSecretValue("OrdnanceSurveyAPIKey"))
+                    .thenReturn(TEST_API_KEY);
+
             when(mockConfigurationService.getParameterValue(
                             "OrdnanceSurveyAPIUrl/" + TEST_CLIENT_ID))
                     .thenReturn("http://localhost:8080/");
@@ -137,6 +143,9 @@ class PostcodeLookupServiceTest {
                 "it should throw Error due to library incompatibility issues. check project build configuration"
                         + "and ipv-cri-lib dependencies for version mismatches")
         void noSuchFieldErrorThrowsProcessingException() throws IOException, InterruptedException {
+            when(mockConfigurationService.getSecretValue("OrdnanceSurveyAPIKey"))
+                    .thenReturn(TEST_API_KEY);
+
             // Mock a valid url so service doesn't fall over validating URI
             when(mockConfigurationService.getParameterValue(
                             "OrdnanceSurveyAPIUrl/" + TEST_CLIENT_ID))
@@ -154,6 +163,9 @@ class PostcodeLookupServiceTest {
 
         @Test
         void ioExceptionThrowsProcessingException() throws IOException, InterruptedException {
+            when(mockConfigurationService.getSecretValue("OrdnanceSurveyAPIKey"))
+                    .thenReturn(TEST_API_KEY);
+
             // Mock a valid url so service doesn't fall over validating URI
             when(mockConfigurationService.getParameterValue(
                             "OrdnanceSurveyAPIUrl/" + TEST_CLIENT_ID))
@@ -171,6 +183,9 @@ class PostcodeLookupServiceTest {
 
         @Test
         void interruptedThrowsProcessingException() throws IOException, InterruptedException {
+            when(mockConfigurationService.getSecretValue("OrdnanceSurveyAPIKey"))
+                    .thenReturn(TEST_API_KEY);
+
             // Mock a valid url so service doesn't fall over validating URI
             when(mockConfigurationService.getParameterValue(
                             "OrdnanceSurveyAPIUrl/" + TEST_CLIENT_ID))
@@ -188,6 +203,9 @@ class PostcodeLookupServiceTest {
 
         @Test
         void non200ThrowsProcessingException() throws IOException, InterruptedException {
+            when(mockConfigurationService.getSecretValue("OrdnanceSurveyAPIKey"))
+                    .thenReturn(TEST_API_KEY);
+
             // Mock a valid url so service doesn't fall over validating URI
             when(mockConfigurationService.getParameterValue(
                             "OrdnanceSurveyAPIUrl/" + TEST_CLIENT_ID))
@@ -209,6 +227,9 @@ class PostcodeLookupServiceTest {
     class PostCodeLookUpServiceOrdnanceSurvey400BadRequestTest {
         @Test
         void badRequestReturnsEmptyButLogs() throws IOException, InterruptedException {
+            when(mockConfigurationService.getSecretValue("OrdnanceSurveyAPIKey"))
+                    .thenReturn(TEST_API_KEY);
+
             // Mock a valid url so service doesn't fall over validating URI
             when(mockConfigurationService.getParameterValue(
                             "OrdnanceSurveyAPIUrl/" + TEST_CLIENT_ID))
@@ -231,6 +252,9 @@ class PostcodeLookupServiceTest {
 
         @Test
         void badRequestReturnsEmptyButLogsWithDetails() throws IOException, InterruptedException {
+            when(mockConfigurationService.getSecretValue("OrdnanceSurveyAPIKey"))
+                    .thenReturn(TEST_API_KEY);
+
             // Mock a valid url so service doesn't fall over validating URI
             when(mockConfigurationService.getParameterValue(
                             "OrdnanceSurveyAPIUrl/" + TEST_CLIENT_ID))
@@ -291,6 +315,9 @@ class PostcodeLookupServiceTest {
     class PostCodeLookUpServiceOrdnanceSurvey200OkTest {
         @Test
         void validPostcodeReturnsResults() throws IOException, InterruptedException {
+            when(mockConfigurationService.getSecretValue("OrdnanceSurveyAPIKey"))
+                    .thenReturn(TEST_API_KEY);
+
             // Mock a valid url so service doesn't fall over validating URI
             when(mockConfigurationService.getParameterValue(
                             "OrdnanceSurveyAPIUrl/" + TEST_CLIENT_ID))
@@ -314,6 +341,9 @@ class PostcodeLookupServiceTest {
                 "Should return empty when response from Ordnance Survey is 200 but results contain an empty DPA object")
         void shouldReturnEmptyWhenResponseFromOrdnanceSurveyIs200WithEmptyDPA()
                 throws IOException, InterruptedException {
+            when(mockConfigurationService.getSecretValue("OrdnanceSurveyAPIKey"))
+                    .thenReturn(TEST_API_KEY);
+
             when(mockConfigurationService.getParameterValue(
                             "OrdnanceSurveyAPIUrl/" + TEST_CLIENT_ID))
                     .thenReturn("http://localhost:8080/");
@@ -339,6 +369,9 @@ class PostcodeLookupServiceTest {
                 "it should return empty when response from Ordnance Survey is a 200 and no results provided")
         void shouldReturnEmptyWhenResponseFromOrdnanceSurveyIsA200WResultsArrayEmpty()
                 throws IOException, InterruptedException {
+            when(mockConfigurationService.getSecretValue("OrdnanceSurveyAPIKey"))
+                    .thenReturn(TEST_API_KEY);
+
             // Mock a valid url so service doesn't fall over validating URI
             when(mockConfigurationService.getParameterValue(
                             "OrdnanceSurveyAPIUrl/" + TEST_CLIENT_ID))
@@ -368,6 +401,9 @@ class PostcodeLookupServiceTest {
     class PostCodeLookUpServiceOrdnanceSurvey404NotFoundTest {
         @Test
         void notFoundReturnsNoResults() throws IOException, InterruptedException {
+            when(mockConfigurationService.getSecretValue("OrdnanceSurveyAPIKey"))
+                    .thenReturn(TEST_API_KEY);
+
             // Mock a valid url so service doesn't fall over validating URI
             when(mockConfigurationService.getParameterValue(
                             "OrdnanceSurveyAPIUrl/" + TEST_CLIENT_ID))

--- a/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
+++ b/lambdas/postcode-lookup/src/test/java/uk/gov/di/ipv/cri/address/api/service/PostcodeLookupServiceTest.java
@@ -365,6 +365,27 @@ class PostcodeLookupServiceTest {
         }
 
         @Test
+        void shouldSetApiKeyAsHeader() throws IOException, InterruptedException {
+            when(mockConfigurationService.getSecretValue("OrdnanceSurveyAPIKey"))
+                    .thenReturn(TEST_API_KEY);
+            when(mockConfigurationService.getParameterValue(
+                            "OrdnanceSurveyAPIUrl/" + TEST_CLIENT_ID))
+                    .thenReturn("http://localhost:8080/");
+            when(mockResponse.statusCode()).thenReturn(HttpStatusCode.OK);
+            when(mockResponse.body()).thenReturn("{\"header\":{},\"results\":[]}");
+            when(httpClient.send(
+                            postCodeRequest.capture(),
+                            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+                    .thenReturn(mockResponse);
+
+            postcodeLookupService.lookupPostcode("ZZ1 1ZZ", TEST_CLIENT_ID);
+
+            HttpRequest capturedRequest = postCodeRequest.getValue();
+            assertEquals(TEST_API_KEY, capturedRequest.headers().firstValue("key").orElse(null));
+            assertFalse(capturedRequest.uri().getQuery().contains("key="));
+        }
+
+        @Test
         @DisplayName(
                 "it should return empty when response from Ordnance Survey is a 200 and no results provided")
         void shouldReturnEmptyWhenResponseFromOrdnanceSurveyIsA200WResultsArrayEmpty()


### PR DESCRIPTION
## Proposed changes

### Why did it change
Using a header is more secure than using a query string parameter.

https://docs.os.uk/os-apis/core-concepts/authentication#http-header

### Verification
Updated `/preview-address-api-oj-1135/OrdnanceSurveyAPIUrl/ipv-core-stub-aws-headless` SSM parameter to OS API URL
Updated `/pre-merge-test/OrdnanceSurveyAPIKey` Secret to OS API Key

Reverted for checks to pass

### Issue tracking
- [OJ-1135](https://govukverify.atlassian.net/browse/OJ-1135)


[OJ-1135]: https://govukverify.atlassian.net/browse/OJ-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ