### PR TITLE
OJ-3654 Re-add mistakenly removed netty exclude statements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ subprojects {
 		exclude group:"software.amazon.awssdk", module: "apache-client"
 		exclude group:"software.amazon.awssdk", module: "netty-nio-client"
 		exclude group:"software.amazon.awssdk", module: "url-connection-client"
+
+		exclude group: "io.netty", module: "*"
+		exclude group: "ip.grpc", module: "grpc-netty"
 	}
 
 	dependencies {


### PR DESCRIPTION
## Proposed changes

### What changed

- Re-added excludes for `io.netty.*` and `io.grpc.grpc-netty`

### Why did it change

- In the previous PR (#1429), we should have removed only the if statement wrapping the excludes, but we removed the entire block, thus removing the excludes entirely rather than applying them all the time as intended

### Issue tracking

- OJ-3654

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks