### PR TITLE
OJ-3670: feat - add unhappy scenarios for OS api url

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ lambda = { module = "software.amazon.awssdk:lambda" }
 aws-lambda-events = { module = "com.amazonaws:aws-lambda-java-events", version.ref = "aws-lambda-events" }
 sqs = { module = "software.amazon.awssdk:sqs" }
 kms = { module = "software.amazon.awssdk:kms" }
+secrets = { module = "software.amazon.awssdk:secretsmanager" }
 lambda-tests = { module = "com.amazonaws:aws-lambda-java-tests", version = "1.1.2" }
 
 # CRI

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -429,6 +429,14 @@ Resources:
         - !FindInMap [DynatraceLayerARN, !Ref Environment, java]
       Environment:
         Variables:
+          CONFIG_SERVICE_SSM_OPTIMIZED_CACHE_AGE_MIN_MINUTES: !If
+            - IsLocalDevEnvironment
+            - 0
+            - !Ref AWS::NoValue
+          CONFIG_SERVICE_SSM_OPTIMIZED_CACHE_AGE_MAX_MINUTES: !If
+            - IsLocalDevEnvironment
+            - 0
+            - !Ref AWS::NoValue
           POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-postcode-lookup"
           SESSION_TABLE: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
           VERIFIABLE_CREDENTIAL_ISSUER: !Sub "{{resolve:ssm:/${CommonStackName}/verifiable-credential/issuer}}"

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	testImplementation libs.bundles.nimbus
 	testImplementation libs.bundles.jackson
 	testImplementation libs.junit.api
+	testImplementation(libs.secrets)
 
 	testImplementation "org.apache.commons:commons-lang3:${apache_common_lang_version}"
 	testImplementation(testFixtures(libs.cri.common.lib))

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -9,10 +9,16 @@ import com.nimbusds.jwt.SignedJWT;
 import gov.uk.address.api.client.AddressApiClient;
 import gov.uk.address.api.util.AddressContext;
 import io.cucumber.datatable.DataTable;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.UpdateSecretRequest;
 import uk.gov.di.ipv.cri.common.library.client.ClientConfigurationService;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEvent;
 import uk.gov.di.ipv.cri.common.library.domain.TestHarnessResponse;
@@ -52,6 +58,10 @@ public class AddressSteps {
     private final String addressEndJsonSchema;
     private final String addressVCIssuedJsonSchema;
     private final AddressContext addressContext;
+    String secretName = "/pre-merge-test/OrdnanceSurveyAPIKey";
+    private final SecretsManagerClient secretsManagerClient =
+            SecretsManagerClient.builder().region(Region.EU_WEST_2).build();
+    private String originalApiKey;
 
     public AddressSteps(
             ClientConfigurationService clientConfigurationService, CriTestContext testContext)
@@ -401,6 +411,11 @@ public class AddressSteps {
         assertEquals(400, this.testContext.getResponse().statusCode());
     }
 
+    @Then("the endpoint should return a 404 HTTP status code")
+    public void theEndpointShouldReturnA401HttpStatusCode() {
+        assertEquals(404, this.testContext.getResponse().statusCode());
+    }
+
     @Given(
             "a request is made to the postcode-lookup endpoint with postcode in the request body with no session id header")
     public void
@@ -408,6 +423,29 @@ public class AddressSteps {
                     throws IOException, InterruptedException {
         this.testContext.setResponse(
                 this.addressApiClient.sendPostCodeLookupRequestWithNoSessionId("TEST"));
+    }
+
+    @Before("@invalid_api_key")
+    public void setInvalidApiKey() {
+        originalApiKey =
+                secretsManagerClient
+                        .getSecretValue(
+                                GetSecretValueRequest.builder().secretId(secretName).build())
+                        .secretString();
+
+        secretsManagerClient.updateSecret(
+                UpdateSecretRequest.builder().secretId(secretName).secretString("abc").build());
+    }
+
+    @After("@invalid_api_key")
+    public void restoreApiKey() throws InterruptedException {
+        secretsManagerClient.updateSecret(
+                UpdateSecretRequest.builder()
+                        .secretId(secretName)
+                        .secretString(originalApiKey)
+                        .build());
+        //Wait for lambda to pick up restored secret
+        Thread.sleep(5000);
     }
 
     @Given(
@@ -441,6 +479,13 @@ public class AddressSteps {
         var responseBody = this.testContext.getResponse().body();
         assertNotNull(responseBody);
         assertEquals("{\"message\": \"Invalid request body\"}", responseBody);
+    }
+
+    @Then("the response body returns the unauthorised {string} response")
+    public void theResponseBodyReturnsUnauthorisedResponse(String errorResponse) {
+        var responseBody = this.testContext.getResponse().body();
+        assertNotNull(responseBody);
+        assertTrue(responseBody.contains(errorResponse));
     }
 
     @Then("the IPV_ADDRESS_CRI_END event is emitted and validated against schema")

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -9,8 +9,6 @@ import com.nimbusds.jwt.SignedJWT;
 import gov.uk.address.api.client.AddressApiClient;
 import gov.uk.address.api.util.AddressContext;
 import io.cucumber.datatable.DataTable;
-import io.cucumber.java.After;
-import io.cucumber.java.Before;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -48,6 +46,7 @@ import static org.junit.Assert.assertTrue;
 public class AddressSteps {
     private static final String ADDRESS_START_SCHEMA_FILE = "/schema/IPV_ADDRESS_CRI_START.json";
     private static final String ADDRESS_END_SCHEMA_FILE = "/schema/IPV_ADDRESS_CRI_END.json";
+    private static final String SECRET_NAME = "/pre-merge-test/OrdnanceSurveyAPIKey";
 
     private static final String ADDRESS_VC_ISSUED_SCHEMA_FILE =
             "/schema/IPV_ADDRESS_CRI_VC_ISSUED.json";
@@ -58,7 +57,6 @@ public class AddressSteps {
     private final String addressEndJsonSchema;
     private final String addressVCIssuedJsonSchema;
     private final AddressContext addressContext;
-    String secretName = "/pre-merge-test/OrdnanceSurveyAPIKey";
     private final SecretsManagerClient secretsManagerClient =
             SecretsManagerClient.builder().region(Region.EU_WEST_2).build();
     private String originalApiKey;
@@ -412,7 +410,8 @@ public class AddressSteps {
     }
 
     @Then("the endpoint should return a 404 HTTP status code")
-    public void theEndpointShouldReturnA401HttpStatusCode() {
+    public void theEndpointShouldReturnA401HttpStatusCode() throws InterruptedException {
+        restoreApiKey();
         assertEquals(404, this.testContext.getResponse().statusCode());
     }
 
@@ -425,27 +424,28 @@ public class AddressSteps {
                 this.addressApiClient.sendPostCodeLookupRequestWithNoSessionId("TEST"));
     }
 
-    @Before("@invalid_api_key")
-    public void setInvalidApiKey() {
+    @Then("user sets an invalid api key {string}")
+    public void setInvalidApiKey(String apikey) throws InterruptedException {
         originalApiKey =
                 secretsManagerClient
                         .getSecretValue(
-                                GetSecretValueRequest.builder().secretId(secretName).build())
+                                GetSecretValueRequest.builder().secretId(SECRET_NAME).build())
                         .secretString();
 
         secretsManagerClient.updateSecret(
-                UpdateSecretRequest.builder().secretId(secretName).secretString("abc").build());
+                UpdateSecretRequest.builder().secretId(SECRET_NAME).secretString(apikey).build());
+        // Wait for lambda to use updated secret
+        Thread.sleep(5000); // NOSONAR
     }
 
-    @After("@invalid_api_key")
     public void restoreApiKey() throws InterruptedException {
         secretsManagerClient.updateSecret(
                 UpdateSecretRequest.builder()
-                        .secretId(secretName)
+                        .secretId(SECRET_NAME)
                         .secretString(originalApiKey)
                         .build());
         // Wait for lambda to pick up restored secret
-        Thread.sleep(5000);
+        Thread.sleep(5000); // NOSONAR
     }
 
     @Given(

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -444,7 +444,7 @@ public class AddressSteps {
                         .secretId(secretName)
                         .secretString(originalApiKey)
                         .build());
-        //Wait for lambda to pick up restored secret
+        // Wait for lambda to pick up restored secret
         Thread.sleep(5000);
     }
 

--- a/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
+++ b/integration-tests/src/test/java/gov/uk/address/api/stepdefinitions/AddressSteps.java
@@ -410,7 +410,7 @@ public class AddressSteps {
     }
 
     @Then("the endpoint should return a 404 HTTP status code")
-    public void theEndpointShouldReturnA401HttpStatusCode() throws InterruptedException {
+    public void theEndpointShouldReturnA404HttpStatusCode() throws InterruptedException {
         restoreApiKey();
         assertEquals(404, this.testContext.getResponse().statusCode());
     }

--- a/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
+++ b/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
@@ -65,3 +65,18 @@ Feature: Address API unhappy path test
     Given a request is made to the address endpoint with a validFrom date of "01-01-2000"
     Then the endpoint should return a 400 HTTP status code
     And the response body contains bad request error
+
+  @invalid_api_key
+  Scenario: Header key is not valid in the postcode-lookup request body
+    Given user has a default signed JWT
+
+    # Session
+    When user sends a POST request to session end point
+    Then user gets a session-id
+
+    # TXMA event
+    When user sends a GET request to events end point for "IPV_ADDRESS_CRI_START"
+    And a valid START event is returned in the response without txma header
+    When the user performs a postcode lookup for post code "SW1A 2AA"
+    Then the endpoint should return a 404 HTTP status code
+    And the response body returns the unauthorised "Invalid ApiKey" response

--- a/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
+++ b/integration-tests/src/test/resources/features/AddressUnhappyPath.feature
@@ -77,6 +77,7 @@ Feature: Address API unhappy path test
     # TXMA event
     When user sends a GET request to events end point for "IPV_ADDRESS_CRI_START"
     And a valid START event is returned in the response without txma header
+    Then user sets an invalid api key "abc"
     When the user performs a postcode lookup for post code "SW1A 2AA"
     Then the endpoint should return a 404 HTTP status code
     And the response body returns the unauthorised "Invalid ApiKey" response


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Add invalid api key scenario for the postcode lookup endpoint. Unable to do the no-api key scenario as secrets manager shows the following when no value is added to the secret: `software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException: 1 validation error detected: Value at 'secretString' failed to satisfy constraint: Member must have length greater than or equal to 1 (Service: SecretsManager, Status Code: 400, Request ID: e90f2ad8-6549-419b-8d9a-8018c92a0424) (SDK Attempt Count: 1)`     

### Why did it change

To increase test coverage.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3670](https://govukverify.atlassian.net/browse/OJ-3670)

## Checklists

### Environment variables or secrets

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks

[OJ-3670]: https://govukverify.atlassian.net/browse/OJ-3670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ