### PR TITLE
feat: add optional X-Forwarded-For header to session endpoint

### DIFF
--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -107,14 +107,15 @@ paths:
 
   /session:
     post:
+      summary: "IP address of the client."
       parameters:
+        - in: header
+          name: "X-Forwarded-For"
+          schema:
+            type: string
+            format: string
+            required: false
         - $ref: "#/components/parameters/AuditHeader"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/Authorization"
-        required: true
       responses:
         "400":
           description: "400 response"

--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -107,15 +107,21 @@ paths:
 
   /session:
     post:
-      summary: "IP address of the client."
       parameters:
         - in: header
           name: "X-Forwarded-For"
+          description: "IP address of the client"
           schema:
             type: string
             format: string
             required: false
         - $ref: "#/components/parameters/AuditHeader"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Authorization"
+        required: true
       responses:
         "400":
           description: "400 response"


### PR DESCRIPTION
## Proposed changes

### What changed
Added the optional X-Forwarded-For header parameter to the /session endpoint in the Address CRI private OpenAPI specification.

### Why did it change
To align the Address CRI session endpoint header configuration with the agreed standard used by Check HMRC. This ensures a consistent API contract across CRIs and removes the need for consumers to implement CRI-specific handling for the X-Forwarded-For header.

### Issue tracking

- [OJ-3801](https://govukverify.atlassian.net/browse/OJ-3801)

[OJ-3801]: https://govukverify.atlassian.net/browse/OJ-3801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ