### PR TITLE
feat: add pre-upload quality gate entries to manifest [OJ-3809]

### DIFF
--- a/quality-gate.manifest.json
+++ b/quality-gate.manifest.json
@@ -44,6 +44,26 @@
           "provider": "GitHub"
         },
         {
+          "check-types": ["unit"],
+          "config": {
+            "file": ".github/workflows/scan-repo.yml",
+            "name": "Test coverage",
+            "path": "jobs.unit-tests-java"
+          },
+          "phase": "pre-upload",
+          "provider": "GitHub"
+        },
+        {
+          "check-types": ["unit"],
+          "config": {
+            "file": ".github/workflows/scan-repo.yml",
+            "name": "Collect coverage",
+            "path": "jobs.unit-tests-ts"
+          },
+          "phase": "pre-upload",
+          "provider": "GitHub"
+        },
+        {
           "check-types": ["contract"],
           "config": {
             "file": ".github/workflows/check-pr.yml",
@@ -104,6 +124,34 @@
             "path": "jobs.codeql-ts"
           },
           "phase": "pre-merge",
+          "provider": "GitHub"
+        },
+        {
+          "check-types": [
+            "code style and linting",
+            "unit test coverage",
+            "vulnerability detection"
+          ],
+          "config": {
+            "file": ".github/workflows/scan-repo.yml",
+            "name": "SonarCloud / Java",
+            "path": "jobs.sonarcloud-java"
+          },
+          "phase": "pre-upload",
+          "provider": "GitHub"
+        },
+        {
+          "check-types": [
+            "code style and linting",
+            "unit test coverage",
+            "vulnerability detection"
+          ],
+          "config": {
+            "file": ".github/workflows/scan-repo.yml",
+            "name": "SonarCloud / TypeScript",
+            "path": "jobs.sonarcloud-ts"
+          },
+          "phase": "pre-upload",
           "provider": "GitHub"
         },
         {


### PR DESCRIPTION

## Proposed changes

### What changed
Updated `quality-gate.manifest.json` to represent unit test and SonarCloud checks that run during the pre-upload stage.

### Why did it change
The repository now executes unit testing and SonarCloud analysis as part of the post-merge/pre-upload pipeline before deployment to build environments. This change updates the quality gate manifest to accurately reflect the current pipeline configuration and support Automated Quality Gates reporting.

### Issue tracking

- [OJ-3809](https://govukverify.atlassian.net/browse/OJ-3809)




[OJ-3809]: https://govukverify.atlassian.net/browse/OJ-3809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ